### PR TITLE
Add the packaging metadata to build the zokrates snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: zokrates
+version: git
+summary: A toolbox for zkSNARKS on Ethereum
+description: |
+  A higher-level language and compiler, which transforms a more convenient
+  representation into verifiable programs based on zkSNARKS.
+  Additionally, generates Ethereum Smart Contraccts, which verify the results
+  on-chain.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  zokrates:
+    command: zokrates
+
+parts:
+  zokrates:
+    source: .
+    plugin: rust
+    rust-channel: nightly
+    build-packages: [g++]
+    rust-features: [nolibsnark]


### PR DESCRIPTION
This package will let you publish the latest zokrates in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.