### PR TITLE
Fix for Issue #7: Fix for 'sym_{i}_{j}' and 'sym_{i}_{j}_b{k}' flattening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "zokrates"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zokrates"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jacob Eberhardt <jacob.eberhardt@tu-berlin.de>", "Dennis Kuhnert <mail@kyroy.com>"]
 repository = "https://github.com/Kyroy/VerifiableStatementCompiler.git"
 readme = "README.md"


### PR DESCRIPTION
Addressing Issue #7 
Fix for symbol reuse when flattening (normally not an issue in simple programs, as normal cases were accounted for; the problem was that the `_b`s were not using the adjusted root names) — I don't know rust at all, so there may be possible issues with these changes. Likely will want a second commit/fixup to change the order of the params (the new `all_vars` should probably be first).