### PR TITLE
Multiple return values

### DIFF
--- a/examples/arity.code
+++ b/examples/arity.code
@@ -1,5 +1,0 @@
-def foo():
-	return 1, 1
-def main():
-	a = foo()
-	return a

--- a/examples/multi_return.code
+++ b/examples/multi_return.code
@@ -1,6 +1,7 @@
-def main(x):
-	x, y = dup(x)
-    return 1
+def foo(a):
+	b = 12*a
+	return a, 2*a, 5*b, a*b
 
-def dup(x):
-	return x, x
+def main(i):
+	x, y, z, t = foo(i)
+    return 1

--- a/examples/multi_return.code
+++ b/examples/multi_return.code
@@ -1,0 +1,6 @@
+def main(x):
+	x, y = dup(x)
+    return 1
+
+def dup(x):
+	return x, x

--- a/examples/multi_return_sum.code
+++ b/examples/multi_return_sum.code
@@ -1,0 +1,5 @@
+def foo():
+   return 1, 2
+def main():
+   a, b = foo()
+   return a + b

--- a/examples/multi_return_sum.code
+++ b/examples/multi_return_sum.code
@@ -2,4 +2,4 @@ def foo():
    return 1, 2
 def main():
    a, b = foo()
-   return a + b
+   return a + b, b - a

--- a/examples/no_args.code
+++ b/examples/no_args.code
@@ -1,3 +1,0 @@
-def main(a):
-  c = 3 + a
-  return 3

--- a/examples/no_args.code
+++ b/examples/no_args.code
@@ -1,3 +1,3 @@
-def main():
+def main(a):
   c = 3 + a
   return 3

--- a/src/absy.rs
+++ b/src/absy.rs
@@ -145,7 +145,7 @@ pub enum Statement<T: Field> {
     Condition(Expression<T>, Expression<T>),
     For(String, T, T, Vec<Statement<T>>),
     Compiler(String, Expression<T>),
-    MultipleDefinition(Expression<T>, Expression<T>),
+    MultipleDefinition(Vec<String>, Expression<T>),
 }
 
 impl<T: Field> Statement<T> {
@@ -177,8 +177,14 @@ impl<T: Field> fmt::Display for Statement<T> {
                 write!(f, "\tendfor")
             }
             Statement::Compiler(ref lhs, ref rhs) => write!(f, "# {} = {}", lhs, rhs),
-            Statement::MultipleDefinition(ref lhs, ref rhs) => {
-                write!(f, "{} = {}", lhs, rhs)
+            Statement::MultipleDefinition(ref ids, ref rhs) => {
+                for (i, id) in ids.iter().enumerate() {
+                    try!(write!(f, "{}", id));
+                    if i < ids.len() - 1 {
+                        try!(write!(f, ", "));
+                    }
+                }
+                write!(f, " = {}", rhs)
             },
         }
     }

--- a/src/absy.rs
+++ b/src/absy.rs
@@ -151,8 +151,7 @@ pub enum Statement<T: Field> {
 impl<T: Field> Statement<T> {
     pub fn is_flattened(&self) -> bool {
         match *self {
-            Statement::Definition(_, ref x) | Statement::MultipleDefinition(_, ref x) => x.is_flattened(),
-            Statement::Return(ref x) => x.is_flattened(),
+            Statement::Definition(_, ref x) | Statement::MultipleDefinition(_, ref x) | Statement::Return(ref x) => x.is_flattened(),
             Statement::Compiler(..) => true,
             Statement::Condition(ref x, ref y) => {
                 (x.is_linear() && y.is_flattened()) || (x.is_flattened() && y.is_linear())
@@ -291,7 +290,7 @@ impl<T: Field> Expression<T> {
                 Expression::FunctionCall(i.clone(), p.clone())
             },
             Expression::List(ref exprs) => {
-                Expression::List(exprs.iter().map(|e| e.apply_substitution(substitution)).collect::<Vec<_>>())
+                Expression::List(exprs.iter().map(|e| e.apply_substitution(substitution)).collect())
             }
         }
     }
@@ -372,7 +371,7 @@ impl<T: Field> Expression<T> {
                 }
             },
             Expression::List(ref exprs) => {
-                exprs.into_iter().fold(true, |acc, x| acc && x.is_flattened())
+                exprs.into_iter().all(|x| x.is_flattened())
             },
             _ => false,
         }

--- a/src/absy.rs
+++ b/src/absy.rs
@@ -81,8 +81,10 @@ impl<T: Field> Function<T> {
                 Statement::Return(ref expr) => {
                     match expr.clone() {
                         Expression::List(values) => {
-                            let s = values[0].solve(&mut witness);
-                            witness.insert("~out".to_string(), s);
+                            for (i, val) in values.iter().enumerate() {
+                                let s = val.solve(&mut witness);
+                                witness.insert(format!("~out_{}", i).to_string(), s);
+                            }
                         },
                         _ => panic!("should return a list")
                     }

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -657,7 +657,7 @@ impl Flattener {
                             statements_flattened.push(Statement::Definition(var, rhs_flattened.expressions[i].clone()));
                         }
                     },
-                    _ => panic!("")
+                    _ => panic!("Right hand side of a MultipleDefinition should be a FunctionCall")
                 }
             },
         }

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -198,6 +198,105 @@ impl Flattener {
         }
     }
 
+    fn flatten_function_call<T: Field>(
+        &mut self,
+        functions_flattened: &Vec<Function<T>>,
+        arguments_flattened: &Vec<Parameter>,
+        statements_flattened: &mut Vec<Statement<T>>,
+        id: &String,
+        param_expressions: &Vec<Expression<T>>
+    ) -> ExpressionList<T> {
+        for funct in functions_flattened {
+            if funct.id == *id && funct.arguments.len() == (*param_expressions).len() {
+                // funct is now the called function
+
+                // Idea: variables are given a prefix.
+                // It consists of the function name followed by a call counter value
+                // e.g.: add_1_a_2
+
+                // Stores prefixed variables
+                let mut replacement_map: HashMap<String, String> = HashMap::new();
+
+                // build prefix
+                match self.function_calls.clone().get(&funct.id) {
+                    Some(val) => {
+                        self.function_calls.insert(funct.id.clone(),val+1);
+                    }
+                    None => {
+                        self.function_calls.insert(funct.id.clone(),1);
+                    }
+                }
+                let prefix = format!("{}_{}_", funct.id.clone(), self.function_calls.get(&funct.id).unwrap());
+
+                // Handle complex parameters and assign values:
+                // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions
+                for (i, param_expr) in param_expressions.iter().enumerate() {
+                    let new_var;
+                    match param_expr.apply_substitution(&self.substitution) {
+                        Expression::Identifier(ref x) => {
+                            new_var = format!("{}param_{}", &prefix, i);
+                                statements_flattened
+                                .push(Statement::Definition(new_var.clone(), Expression::Identifier(x.clone().to_string())));
+                        },
+                        _ => {
+                            let expr_subbed = param_expr.apply_substitution(&self.substitution);
+                            let rhs = self.flatten_expression(
+                                functions_flattened,
+                                arguments_flattened,
+                                statements_flattened,
+                                expr_subbed,
+                            );
+                            new_var = format!("{}param_{}", &prefix, i);
+                            statements_flattened
+                                .push(Statement::Definition(new_var.clone(), rhs));
+                        }
+                    }
+                    replacement_map.insert(funct.arguments.get(i).unwrap().id.clone(), new_var);
+                }
+
+                // Ensure Renaming and correct returns:
+                // add all flattened statements, adapt return statement
+                for stat in funct.statements.clone() {
+                    assert!(stat.is_flattened(), format!("Not flattened: {}", &stat));
+                    match stat {
+                        // set return statements right side as expression result
+                        Statement::Return(list) => {
+                            return ExpressionList {
+                                expressions: list.expressions.into_iter().map(|x| x.apply_substitution(&replacement_map)).collect()
+                            }
+                        },
+                        Statement::Definition(var, rhs) => {
+                            let new_rhs = rhs.apply_substitution(&replacement_map);
+                            let new_var: String = format!("{}{}", prefix, var.clone());
+                            replacement_map.insert(var, new_var.clone());
+                            statements_flattened.push(
+                                Statement::Definition(new_var, new_rhs)
+                            );
+                        },
+                        Statement::Compiler(var, rhs) => {
+                            let new_rhs = rhs.apply_substitution(&replacement_map);
+                            let new_var: String = format!("{}{}", prefix, var.clone());
+                            replacement_map.insert(var, new_var.clone());
+                            statements_flattened.push(Statement::Compiler(new_var, new_rhs));
+                        },
+                        Statement::Condition(lhs, rhs) => {
+                            let new_lhs = lhs.apply_substitution(&replacement_map);
+                            let new_rhs = rhs.apply_substitution(&replacement_map);
+                            statements_flattened
+                                .push(Statement::Condition(new_lhs, new_rhs));
+                        },
+                        _ => panic!("Statement inside function not flattened when flattening function call")
+                    }
+                }
+            }
+        }
+        panic!(
+            "Function definition for function {} with {:?} argument(s) not found.",
+            id,
+            param_expressions
+        );
+    }
+
     /// Returns a flattened `Expression` based on the given `expr`.
     ///
     /// # Arguments
@@ -219,16 +318,6 @@ impl Flattener {
             {
                 x.clone()
             }
-            List(ref exprs) => {
-                let flattened_exprs = exprs.into_iter().map(|x| 
-                    self.flatten_expression(
-                        functions_flattened, 
-                        arguments_flattened, 
-                        statements_flattened, 
-                        x.clone())
-                    ).collect();
-                List(flattened_exprs)
-            },
             Add(box left, box right) => {
                 let left_flattened = self.flatten_expression(
                     functions_flattened,
@@ -431,103 +520,35 @@ impl Flattener {
                 )
             }
             FunctionCall(ref id, ref param_expressions) => {
-                for funct in functions_flattened {
-                    if funct.id == *id && funct.arguments.len() == (*param_expressions).len() {
-                        // funct is now the called function
-
-                        // Idea: variables are given a prefix.
-                        // It consists of the function name followed by a call counter value
-                        // e.g.: add_1_a_2
-
-                        // Stores prefixed variables
-                        let mut replacement_map: HashMap<String, String> = HashMap::new();
-
-                        // build prefix
-                        match self.function_calls.clone().get(&funct.id) {
-                            Some(val) => {
-                                self.function_calls.insert(funct.id.clone(),val+1);
-                            }
-                            None => {
-                                self.function_calls.insert(funct.id.clone(),1);
-                            }
-                        }
-                        let prefix = format!("{}_{}_", funct.id.clone(), self.function_calls.get(&funct.id).unwrap());
-
-                        // Handle complex parameters and assign values:
-                        // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions
-                        for (i, param_expr) in param_expressions.iter().enumerate() {
-                            let new_var;
-                            match param_expr.apply_substitution(&self.substitution) {
-                                Expression::Identifier(ref x) => {
-                                    new_var = format!("{}param_{}", &prefix, i);
-                                        statements_flattened
-                                        .push(Statement::Definition(new_var.clone(), Expression::Identifier(x.clone().to_string())));
-                                },
-                                _ => {
-                                    let expr_subbed = param_expr.apply_substitution(&self.substitution);
-                                    let rhs = self.flatten_expression(
-                                        functions_flattened,
-                                        arguments_flattened,
-                                        statements_flattened,
-                                        expr_subbed,
-                                    );
-                                    new_var = format!("{}param_{}", &prefix, i);
-                                    statements_flattened
-                                        .push(Statement::Definition(new_var.clone(), rhs));
-                                }
-                            }
-                            replacement_map.insert(funct.arguments.get(i).unwrap().id.clone(), new_var);
-                        }
-
-                        // Ensure Renaming and correct returns:
-                        // add all flattened statements, adapt return statement
-                        for stat in funct.statements.clone() {
-                            assert!(stat.is_flattened(), format!("Not flattened: {}", &stat));
-                            match stat {
-                                // set return statements right side as expression result
-                                Statement::Return(x) => {
-                                    match x {
-                                        List(values) => {
-                                            let new_values: Vec<Expression<T>> = values.into_iter().map(|x| x.apply_substitution(&replacement_map)).collect();
-                                            if new_values.len() == 1 {
-                                                return new_values[0].clone();
-                                            }
-                                            return List(new_values);
-                                        },
-                                        _ => panic!("should return a List")
-                                    }
-                                },
-                                Statement::Definition(var, rhs) => {
-                                    let new_rhs = rhs.apply_substitution(&replacement_map);
-                                    let new_var: String = format!("{}{}", prefix, var.clone());
-                                    replacement_map.insert(var, new_var.clone());
-                                    statements_flattened.push(
-                                        Statement::Definition(new_var, new_rhs)
-                                    );
-                                },
-                                Statement::Compiler(var, rhs) => {
-                                    let new_rhs = rhs.apply_substitution(&replacement_map);
-                                    let new_var: String = format!("{}{}", prefix, var.clone());
-                                    replacement_map.insert(var, new_var.clone());
-                                    statements_flattened.push(Statement::Compiler(new_var, new_rhs));
-                                },
-                                Statement::Condition(lhs, rhs) => {
-                                    let new_lhs = lhs.apply_substitution(&replacement_map);
-                                    let new_rhs = rhs.apply_substitution(&replacement_map);
-                                    statements_flattened
-                                        .push(Statement::Condition(new_lhs, new_rhs));
-                                },
-                                _ => panic!("Statement inside function not flattened when flattening function call")
-                            }
-                        }
-                    }
-                }
-                panic!(
-                    "Function definition for function {} with {:?} argument(s) not found.",
+                let exprs_flattened = self.flatten_function_call(
+                    functions_flattened,
+                    arguments_flattened,
+                    statements_flattened,
                     id,
                     param_expressions
                 );
+                assert!(exprs_flattened.expressions.len() == 1); // outside of MultipleDefinition, FunctionCalls must return a single value
+                exprs_flattened.expressions[0].clone()
             }
+        }
+    }
+
+    pub fn flatten_expression_list<T: Field>(
+        &mut self,
+        functions_flattened: &mut Vec<Function<T>>,
+        arguments_flattened: &Vec<Parameter>,
+        statements_flattened: &mut Vec<Statement<T>>,
+        list: ExpressionList<T>,
+    ) -> ExpressionList<T> {
+        let flattened_exprs = list.expressions.into_iter().map(|x| 
+            self.flatten_expression(
+                functions_flattened, 
+                arguments_flattened, 
+                statements_flattened, 
+                x.clone())
+            ).collect();
+        ExpressionList {
+            expressions: flattened_exprs
         }
     }
 
@@ -541,7 +562,7 @@ impl Flattener {
         match *stat {
             Statement::Return(ref exprs) => {
                 let exprs_subbed = exprs.apply_substitution(&self.substitution);
-                let rhs = self.flatten_expression(
+                let rhs = self.flatten_expression_list(
                     functions_flattened,
                     arguments_flattened,
                     statements_flattened,
@@ -616,15 +637,16 @@ impl Flattener {
             ref s @ Statement::Compiler(..) => statements_flattened.push(s.clone()),
             Statement::MultipleDefinition(ref ids, ref rhs) => {
                 let rhs_subbed = rhs.apply_substitution(&self.substitution);
-                let rhs_flattened = self.flatten_expression(
-                    functions_flattened,
-                    arguments_flattened,
-                    statements_flattened,
-                    rhs_subbed,
-                );
+                match rhs_subbed {
+                    FunctionCall(ref fun_id, ref exprs) => {
+                        let rhs_flattened = self.flatten_function_call(
+                            functions_flattened,
+                            arguments_flattened,
+                            statements_flattened,
+                            fun_id,
+                            exprs,
+                        );
 
-                match rhs_flattened {
-                    Expression::List(rhs_list) => {
                         for (i, id) in ids.into_iter().enumerate() {
                             let var = self.use_variable(&id);
                             // handle return of function call
@@ -632,10 +654,10 @@ impl Flattener {
                             if !(var == var_to_replace) && self.variables.contains(&var_to_replace) && !self.substitution.contains_key(&var_to_replace){
                                 self.substitution.insert(var_to_replace.clone().to_string(),var.clone());
                             }
-                            statements_flattened.push(Statement::Definition(var, rhs_list[i].clone()));
+                            statements_flattened.push(Statement::Definition(var, rhs_flattened.expressions[i].clone()));
                         }
                     },
-                    _ => panic!("rhs should flatten to a List, semantics failed")
+                    _ => panic!("")
                 }
             },
         }
@@ -752,10 +774,14 @@ mod multiple_definition {
             Function {
                 id: "foo".to_string(), 
                 arguments: vec![], 
-                statements: vec![Statement::Return(Expression::List(vec![
-                    Expression::Number(FieldPrime::from(1)), 
-                    Expression::Number(FieldPrime::from(2))
-                ]))],
+                statements: vec![Statement::Return(
+                    ExpressionList { 
+                        expressions: vec![
+                            Expression::Number(FieldPrime::from(1)), 
+                            Expression::Number(FieldPrime::from(2))
+                        ]
+                    }
+                )],
                 return_count: 2,
             }
         ];
@@ -796,10 +822,14 @@ mod multiple_definition {
             Function {
                 id: "dup".to_string(), 
                 arguments: vec![Parameter { id: "x".to_string(), private: true }], 
-                statements: vec![Statement::Return(Expression::List(vec![
-                    Expression::Identifier("x".to_string()), 
-                    Expression::Identifier("x".to_string()), 
-                ]))],
+                statements: vec![Statement::Return(
+                    ExpressionList { 
+                        expressions: vec![
+                            Expression::Identifier("x".to_string()), 
+                            Expression::Identifier("x".to_string()), 
+                        ]
+                    }
+                )],
                 return_count: 2,
             }
         ];
@@ -843,9 +873,13 @@ mod multiple_definition {
             Function {
                 id: "foo".to_string(), 
                 arguments: vec![], 
-                statements: vec![Statement::Return(Expression::List(vec![
-                    Expression::Number(FieldPrime::from(1))
-                ]))],
+                statements: vec![Statement::Return(
+                    ExpressionList { 
+                        expressions: vec![
+                            Expression::Number(FieldPrime::from(1))
+                        ]
+                    }
+                )],
                 return_count: 1,
             }
         ];

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -500,6 +500,7 @@ impl Flattener {
                                         .push(Statement::Condition(new_lhs, new_rhs));
                                 },
                                 Statement::For(..) => panic!("Not flattened!"),
+                                Statement::MultipleDefinition(..) => unimplemented!(),
                             }
                         }
                     }
@@ -509,7 +510,8 @@ impl Flattener {
                     id,
                     param_expressions
                 );
-            }
+            },
+            _ => unimplemented!()
         }
     }
 
@@ -594,6 +596,7 @@ impl Flattener {
                 }
             }
             ref s @ Statement::Compiler(..) => statements_flattened.push(s.clone()),
+            Statement::MultipleDefinition(..) => unimplemented!(),
         }
     }
 
@@ -632,6 +635,7 @@ impl Flattener {
             id: funct.id,
             arguments: arguments_flattened,
             statements: statements_flattened,
+            return_count: 1
         }
     }
 

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -442,7 +442,6 @@ impl Flattener {
                             }
                         }
                         let prefix = format!("{}_{}_", funct.id.clone(), self.function_calls.get(&funct.id).unwrap());
-                        println!("Function Prefix {}",prefix);
 
                         // Handle complex parameters and assign values:
                         // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,10 +348,6 @@ fn main() {
             let witness_map = main_flattened.get_witness(arguments);
             // let witness_map: HashMap<String, FieldPrime> = main_flattened.get_witness(args);
             println!("Witness: {:?}", witness_map);
-            match witness_map.get("~out") {
-                Some(out) => println!("Returned (~out): {}", out),
-                None => println!("~out not found, no value returned")
-            }
 
             // write witness to file
             let output_path = Path::new(sub_matches.value_of("output").unwrap());
@@ -425,7 +421,7 @@ fn main() {
             // run setup phase
             #[cfg(not(feature="nolibsnark"))]{
                 // number of inputs in the zkSNARK sense, i.e., input variables + output variables
-                let num_inputs = main_flattened.arguments.iter().filter(|x| !x.private).count() + 1;
+                let num_inputs = main_flattened.arguments.iter().filter(|x| !x.private).count() + main_flattened.return_count;
                 println!("setup successful: {:?}", setup(variables, a, b, c, num_inputs, pk_path, vk_path));
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1119,29 +1119,21 @@ fn parse_statement<T: Field>(
             }),
         },
         (Token::Return, s1, p1) => match parse_expression_list(s1, p1) {
-            Ok((Expression::List(xs), s2, p2)) => match next_token(&s2, &p2) {
+            Ok((e2, s2, p2)) => match next_token(&s2, &p2) {
                 (Token::InlineComment(_), ref s3, _) => {
                     assert_eq!(s3, "");
-                    Ok((Statement::Return(Expression::List(xs)), s2, p2))
+                    Ok((Statement::Return(e2), s2, p2))
                 }
                 (Token::Unknown(ref t3), ref s3, _) if t3 == "" => {
                     assert_eq!(s3, "");
-                    Ok((Statement::Return(Expression::List(xs)), s2, p2))
+                    Ok((Statement::Return(e2), s2, p2))
                 }
-                (t4, _, p4) => Err(Error {
-                    expected: vec![
-                        Token::Add,
-                        Token::Sub,
-                        Token::Pow,
-                        Token::Mult,
-                        Token::Div,
-                        Token::Unknown("".to_string()),
-                    ],
-                    got: t4,
-                    pos: p4,
+                (t3, _, p3) => Err(Error {
+                    expected: vec![Token::Unknown("".to_string())],
+                    got: t3,
+                    pos: p3,
                 }),
             },
-            Ok(..) => unimplemented!(),
             Err(err) => Err(err),
         },
         (Token::Def, _, p1) => Err(Error {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1586,10 +1586,19 @@ mod tests {
     }
 
     #[cfg(test)]
-    mod parse_destructure {
+    mod parse_comma_separated_list {
         use super::*;
+
+        fn parse_comma_separated_list<T: Field>(
+            input: String, 
+            pos: Position
+        ) -> Result<(Vec<Expression<T>>, String, Position), Error<T>> { 
+            let mut res = Vec::new();
+            parse_comma_separated_list_rec(input, pos, &mut res) 
+        }
+
         #[test]
-        fn destructure1() {
+        fn comma_separated_list1() {
             let pos = Position { line: 45, col: 121 };
             let string = String::from("b, c");
             let expr = Expression::List::<FieldPrime>(vec![Expression::Identifier(String::from("a")),Expression::Identifier(String::from("b")),Expression::Identifier(String::from("c"))]);
@@ -1600,7 +1609,7 @@ mod tests {
         }
 
         #[test]
-        fn destructure() {
+        fn comma_separated_list() {
             let pos = Position { line: 45, col: 121 };
             let string = String::from("b, c");
             let expr = Expression::List::<FieldPrime>(vec![Expression::Identifier(String::from("b")),Expression::Identifier(String::from("c"))]);
@@ -1611,7 +1620,7 @@ mod tests {
         }
 
         #[test]
-        fn destructure_single() {
+        fn comma_separated_list_single() {
             let pos = Position { line: 45, col: 121 };
             let string = String::from("a");
             let exprs = vec![Expression::Identifier(String::from("a"))];
@@ -1622,18 +1631,7 @@ mod tests {
         }
 
         #[test]
-        fn destructure_two() {
-            let pos = Position { line: 45, col: 121 };
-            let string = String::from("a, b");
-            let exprs = vec![Expression::Identifier(String::from("a")),Expression::Identifier(String::from("b"))];
-            assert_eq!(
-                Ok((exprs, String::from(""), pos.col(string.len() as isize))),
-                parse_comma_separated_list::<FieldPrime>(string, pos)
-            )
-        }
-
-        #[test]
-        fn destructure_three() {
+        fn comma_separated_list_three() {
             let pos = Position { line: 45, col: 121 };
             let string = String::from("a, b, c");
             let exprs = vec![Expression::Identifier(String::from("a")),Expression::Identifier(String::from("b")),Expression::Identifier(String::from("c"))];

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -304,14 +304,19 @@ pub fn r1cs_program<T: Field>(
         let mut b_row: Vec<(usize, T)> = Vec::new();
         let mut c_row: Vec<(usize, T)> = Vec::new();
         match *def {
-            Statement::Return(ref expr) => r1cs_expression(
-                Identifier("~out".to_string()),
-                expr.clone(),
-                &mut variables,
-                &mut a_row,
-                &mut b_row,
-                &mut c_row,
-            ),
+            Statement::Return(ref expr) => {
+                match expr.clone() {
+                    Expression::List(values) => r1cs_expression(
+                        Identifier("~out".to_string()),
+                        values[0].clone(),
+                        &mut variables,
+                        &mut a_row,
+                        &mut b_row,
+                        &mut c_row,
+                    ),
+                    _ => panic!("should return a List")
+                }
+            },
             Statement::Definition(ref id, ref expr) => r1cs_expression(
                 Identifier(id.to_string()),
                 expr.clone(),

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -244,6 +244,7 @@ fn r1cs_expression<T: Field>(
                 c_row.push((get_variable_idx(variables, &key), value));
             }
         }
+        _ => unimplemented!()
     }
 }
 
@@ -329,6 +330,7 @@ pub fn r1cs_program<T: Field>(
             ),
             Statement::For(..) => panic!("For-loop not flattened"),
             Statement::Compiler(..) => continue,
+            Statement::MultipleDefinition(..) => unimplemented!(),
         }
         a.push(a_row);
         b.push(b_row);

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -295,7 +295,9 @@ pub fn r1cs_program<T: Field>(
 
     // ~out is added after main's arguments as we want variables (columns)
     // in the r1cs to be aligned like "public inputs | private inputs"
-    variables.push("~out".to_string());
+    for i in 0..main.return_count {
+        variables.push(format!("~out_{}", i).to_string());
+    }
 
     // position where private part of witness starts
     let private_inputs_offset = variables.len();
@@ -307,14 +309,18 @@ pub fn r1cs_program<T: Field>(
         match *def {
             Statement::Return(ref expr) => {
                 match expr.clone() {
-                    Expression::List(values) => r1cs_expression(
-                        Identifier("~out".to_string()),
-                        values[0].clone(),
-                        &mut variables,
-                        &mut a_row,
-                        &mut b_row,
-                        &mut c_row,
-                    ),
+                    Expression::List(values) => {
+                        for (i, val) in values.iter().enumerate() {
+                            r1cs_expression(
+                                Identifier(format!("~out_{}", i).to_string()),
+                                val.clone(),
+                                &mut variables,
+                                &mut a_row,
+                                &mut b_row,
+                                &mut c_row,
+                            )
+                        }
+                    },
                     _ => panic!("should return a List")
                 }
             },

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -244,7 +244,6 @@ fn r1cs_expression<T: Field>(
                 c_row.push((get_variable_idx(variables, &key), value));
             }
         }
-        _ => unimplemented!()
     }
 }
 
@@ -304,27 +303,22 @@ pub fn r1cs_program<T: Field>(
 
     for def in &main.statements {
         match *def {
-            Statement::Return(ref expr) => {
-                match expr.clone() {
-                    Expression::List(values) => {
-                        for (i, val) in values.iter().enumerate() {
-                            let mut a_row: Vec<(usize, T)> = Vec::new();
-                            let mut b_row: Vec<(usize, T)> = Vec::new();
-                            let mut c_row: Vec<(usize, T)> = Vec::new();
-                            r1cs_expression(
-                                Identifier(format!("~out_{}", i).to_string()),
-                                val.clone(),
-                                &mut variables,
-                                &mut a_row,
-                                &mut b_row,
-                                &mut c_row,
-                            );
-                            a.push(a_row);
-                            b.push(b_row);
-                            c.push(c_row);
-                        }
-                    },
-                    _ => panic!("should return a List")
+            Statement::Return(ref list) => {
+                for (i, val) in list.expressions.iter().enumerate() {
+                    let mut a_row: Vec<(usize, T)> = Vec::new();
+                    let mut b_row: Vec<(usize, T)> = Vec::new();
+                    let mut c_row: Vec<(usize, T)> = Vec::new();
+                    r1cs_expression(
+                        Identifier(format!("~out_{}", i).to_string()),
+                        val.clone(),
+                        &mut variables,
+                        &mut a_row,
+                        &mut b_row,
+                        &mut c_row,
+                    );
+                    a.push(a_row);
+                    b.push(b_row);
+                    c.push(c_row);
                 }
             },
             Statement::Definition(_, _) => continue,

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -83,8 +83,8 @@ impl Checker {
 
 	fn check_statement<T: Field>(&mut self, stat: Statement<T>) -> Result<(), String> {
 		match stat {
-			Statement::Return(expr) => {
-				self.check_expression(expr)?;
+			Statement::Return(list) => {
+				self.check_expression_list(list)?;
 				Ok(())
 			}
 			Statement::Definition(id, expr) | Statement::Compiler(id, expr) => {
@@ -171,14 +171,15 @@ impl Checker {
 				}
 				Ok(())
 			}
-			Expression::Number(_) => Ok(()),
-			Expression::List(exprs) => {
-				for expr in exprs {
-					self.check_expression(expr)?
-				}
-				Ok(())
-			}
+			Expression::Number(_) => Ok(())
 		}
+	}
+
+	fn check_expression_list<T: Field>(&mut self, list: ExpressionList<T>) -> Result<(), String> {
+		for expr in list.expressions { // implement Iterator trait?
+			self.check_expression(expr)?
+		}
+		Ok(())
 	}
 
 	fn check_condition<T: Field>(&mut self, cond: Condition<T>) -> Result<(), String> {
@@ -257,7 +258,9 @@ mod tests {
         let bar_args = Vec::<Parameter>::new();
 		let mut bar_statements = Vec::<Statement<FieldPrime>>::new();
 		bar_statements.push(Statement::Return(
-			Expression::Identifier(String::from("a"))
+			ExpressionList {
+				expressions: vec![Expression::Identifier(String::from("a"))]
+			}			
 		));
 		let bar = Function {
             id: "bar".to_string(),
@@ -305,7 +308,9 @@ mod tests {
 			Expression::Number(FieldPrime::from(2))
 		));
 		bar_statements.push(Statement::Return(
-			Expression::Identifier(String::from("a"))
+			ExpressionList {
+				expressions: vec![Expression::Identifier(String::from("a"))]
+			}
 		));
 		let bar = Function {
             id: "bar".to_string(),
@@ -340,7 +345,9 @@ mod tests {
 			Vec::<Statement<FieldPrime>>::new())
 		);
 		foo_statements.push(Statement::Return(
-			Expression::Identifier(String::from("i"))
+			ExpressionList {
+				expressions: vec![Expression::Identifier(String::from("i"))]
+			}
 		));
 		let foo = Function {
 			id: "foo".to_string(),
@@ -442,10 +449,10 @@ mod tests {
 		//   return a, b
 		// should fail
 		let bar_statements: Vec<Statement<FieldPrime>> = vec![Statement::Return(
-			Expression::List(vec![
+			ExpressionList { expressions: vec![
 				Expression::Identifier("a".to_string()),
 				Expression::Identifier("b".to_string())
-			])
+			]}
 		)];
 
 		let bar = Function {
@@ -474,12 +481,12 @@ mod tests {
 				Expression::FunctionCall("foo".to_string(), vec![])
 			),
 			Statement::Return(
-				Expression::List(vec![
+				ExpressionList { expressions: vec![
 					Expression::Add(
 						box Expression::Identifier("a".to_string()), 
 						box Expression::Identifier("b".to_string())
 					)]
-				)
+				}
 			)
 		];
 

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -183,7 +183,10 @@ impl Checker {
 				Ok(())
 			}
 			Expression::Number(_) => Ok(()),
-			Expression::List(values) => {
+			Expression::List(exprs) => {
+				for expr in exprs {
+					self.check_expression(expr)?
+				}
 				Ok(())
 			}
 		}
@@ -442,5 +445,28 @@ mod tests {
 
 		let mut checker = Checker::new_with_args(HashSet::new(), 0, HashSet::new());
 		assert_eq!(checker.check_function(bar), Err(("Function definition for function ??? with ??? argument(s) not found.".to_string())));
+	}
+
+	#[test]
+	fn return_undefined() {
+		// def bar():
+		//   return a, b
+		// should fail
+		let bar_statements: Vec<Statement<FieldPrime>> = vec![Statement::Return(
+			Expression::List(vec![
+				Expression::Identifier("a".to_string()),
+				Expression::Identifier("b".to_string())
+			])
+		)];
+
+		let bar = Function {
+			id: "bar".to_string(),
+			arguments: vec![],
+			statements: bar_statements,
+			return_count: 2
+		};
+
+		let mut checker = Checker::new_with_args(HashSet::new(), 0, HashSet::new());
+		assert_eq!(checker.check_function(bar), Err(("\"a\" is undefined".to_string())));
 	}
 }


### PR DESCRIPTION
Enable this code to work:

```
def foo():
   return 1, 2
def main():
   a, b = foo()
   return a + b, b - a
```

Todo
- [x] Adapt r1cs for multiple outputs (fails when generating proof)
- [ ] Get rid of as many `.clone()` as possible ⚡️ 
- [ ] More tests, include semantics in e2e tests
- [ ] Do we need to give an offset for outputs, or checking variable names is enough? (first `out_`, make sure users can't use that name)