### PR TITLE
Support function overloading in flattener

### DIFF
--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -903,4 +903,69 @@ mod multiple_definition {
             Statement::Definition("a".to_string(), Expression::Number(FieldPrime::from(1)))
         );
     }
+
+    #[test]
+    fn overload() {
+
+        // def foo()
+        //      return 1
+        // def foo()
+        //      return 1, 2
+        // def main()
+        //      a = foo()
+        //      b, c = foo()
+        //      return 1
+        //
+        //      should not panic    
+        //
+
+        let mut flattener = Flattener::new(FieldPrime::get_required_bits());
+        let functions = vec![
+            Function {
+                id: "foo".to_string(), 
+                arguments: vec![], 
+                statements: vec![Statement::Return(
+                    ExpressionList { 
+                        expressions: vec![
+                            Expression::Number(FieldPrime::from(1))
+                        ]
+                    }
+                )],
+                return_count: 1,
+            },
+            Function {
+                id: "foo".to_string(), 
+                arguments: vec![], 
+                statements: vec![Statement::Return(
+                    ExpressionList { 
+                        expressions: vec![
+                            Expression::Number(FieldPrime::from(1)),
+                            Expression::Number(FieldPrime::from(2))
+                        ]
+                    }
+                )],
+                return_count: 2,
+            },
+            Function {
+                id: "main".to_string(),
+                arguments: vec![],
+                statements: vec![
+                    Statement::Definition("a".to_string(), Expression::FunctionCall("foou".to_string(), vec![])),
+                    Statement::MultipleDefinition(vec!["b".to_string(), "c".to_string()], Expression::FunctionCall("foo".to_string(), vec![])),
+                    Statement::Return(ExpressionList {
+                        expressions: vec![Expression::Number(FieldPrime::from(1))]
+                    })
+                ],
+                return_count: 1
+            }
+        ];
+
+        let p = flattener.flatten_program(
+            Prog {
+                functions: functions
+            }
+        );
+
+        // shouldn't panic
+    }
 }

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -857,7 +857,7 @@ mod multiple_definition {
         assert_eq!(
             statements_flattened[0]
             ,
-            FlatStatement::Definition("dup_1_param_0".to_string(), FlatExpression::Number(FieldPrime::from(2)))
+            FlatStatement::Definition("dup_i1o2_1_param_0".to_string(), FlatExpression::Number(FieldPrime::from(2)))
         );
     }
 

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -950,7 +950,7 @@ mod multiple_definition {
                 id: "main".to_string(),
                 arguments: vec![],
                 statements: vec![
-                    Statement::Definition("a".to_string(), Expression::FunctionCall("foou".to_string(), vec![])),
+                    Statement::Definition("a".to_string(), Expression::FunctionCall("foo".to_string(), vec![])),
                     Statement::MultipleDefinition(vec!["b".to_string(), "c".to_string()], Expression::FunctionCall("foo".to_string(), vec![])),
                     Statement::Return(ExpressionList {
                         expressions: vec![Expression::Number(FieldPrime::from(1))]

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -960,7 +960,7 @@ mod multiple_definition {
             }
         ];
 
-        let p = flattener.flatten_program(
+        flattener.flatten_program(
             Prog {
                 functions: functions
             }


### PR DESCRIPTION
Currently, the flattener names variables generated by function calls based on function name and index of the call:  `foo_42_bar_33` for the 33rd call to `bar` inside the 42nd call to `foo`

This can break when functions are overloaded, like the following example:

```
def foo()
     return 1
def foo()
     return 1, 2
def main()
     a = foo()
     b, c = foo()
     return 1
```

I'm not 100% familiar with how the flattener works, so would welcome some feedback @JacobEberhardt 