### PR TITLE
fix solidity warnings in smart contract template

### DIFF
--- a/src/verification.rs
+++ b/src/verification.rs
@@ -17,11 +17,11 @@ library Pairing {
         uint[2] Y;
     }
     /// @return the generator of G1
-    function P1() internal returns (G1Point) {
+    function P1() pure internal returns (G1Point) {
         return G1Point(1, 2);
     }
     /// @return the generator of G2
-    function P2() internal returns (G2Point) {
+    function P2() pure internal returns (G2Point) {
         return G2Point(
             [11559732032986387107991004021392285783925812861821192530917403151452391805634,
              10857046999023057135944570762232829481370756359578518086990519993285655852781],
@@ -29,8 +29,8 @@ library Pairing {
              8495653923123431417604973247489272438418190587263600148770280649306958101930]
         );
     }
-    /// @return the negation of p, i.e. p.add(p.negate()) should be zero.
-    function negate(G1Point p) internal returns (G1Point) {
+    /// @return the negation of p, i.e. p.addition(p.negate()) should be zero.
+    function negate(G1Point p) pure internal returns (G1Point) {
         // The prime q in the base field F_q for G1
         uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
         if (p.X == 0 && p.Y == 0)
@@ -38,7 +38,7 @@ library Pairing {
         return G1Point(p.X, q - (p.Y % q));
     }
     /// @return the sum of two points of G1
-    function add(G1Point p1, G1Point p2) internal returns (G1Point r) {
+    function addition(G1Point p1, G1Point p2) internal returns (G1Point r) {
         uint[4] memory input;
         input[0] = p1.X;
         input[1] = p1.Y;
@@ -48,13 +48,13 @@ library Pairing {
         assembly {
             success := call(sub(gas, 2000), 6, 0, input, 0xc0, r, 0x60)
             // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid }
+            switch success case 0 { invalid() }
         }
         require(success);
     }
     /// @return the product of a point on G1 and a scalar, i.e.
-    /// p == p.mul(1) and p.add(p) == p.mul(2) for all points p.
-    function mul(G1Point p, uint s) internal returns (G1Point r) {
+    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
+    function scalar_mul(G1Point p, uint s) internal returns (G1Point r) {
         uint[3] memory input;
         input[0] = p.X;
         input[1] = p.Y;
@@ -63,7 +63,7 @@ library Pairing {
         assembly {
             success := call(sub(gas, 2000), 7, 0, input, 0x80, r, 0x60)
             // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid }
+            switch success case 0 { invalid() }
         }
         require (success);
     }
@@ -90,7 +90,7 @@ library Pairing {
         assembly {
             success := call(sub(gas, 2000), 8, 0, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
             // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid }
+            switch success case 0 { invalid() }
         }
         require(success);
         return out[0] != 0;
@@ -163,7 +163,7 @@ contract Verifier {
         Pairing.G1Point K;
         Pairing.G1Point H;
     }
-    function verifyingKey() internal returns (VerifyingKey vk) {
+    function verifyingKey() pure internal returns (VerifyingKey vk) {
         vk.A = Pairing.G2Point(<%vk_a%>);
         vk.B = Pairing.G1Point(<%vk_b%>);
         vk.C = Pairing.G2Point(<%vk_c%>);
@@ -180,18 +180,18 @@ contract Verifier {
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
         for (uint i = 0; i < input.length; i++)
-            vk_x = Pairing.add(vk_x, Pairing.mul(vk.IC[i + 1], input[i]));
-        vk_x = Pairing.add(vk_x, vk.IC[0]);
+            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+        vk_x = Pairing.addition(vk_x, vk.IC[0]);
         if (!Pairing.pairingProd2(proof.A, vk.A, Pairing.negate(proof.A_p), Pairing.P2())) return 1;
         if (!Pairing.pairingProd2(vk.B, proof.B, Pairing.negate(proof.B_p), Pairing.P2())) return 2;
         if (!Pairing.pairingProd2(proof.C, vk.C, Pairing.negate(proof.C_p), Pairing.P2())) return 3;
         if (!Pairing.pairingProd3(
             proof.K, vk.gamma,
-            Pairing.negate(Pairing.add(vk_x, Pairing.add(proof.A, proof.C))), vk.gammaBeta2,
+            Pairing.negate(Pairing.addition(vk_x, Pairing.addition(proof.A, proof.C))), vk.gammaBeta2,
             Pairing.negate(vk.gammaBeta1), proof.B
         )) return 4;
         if (!Pairing.pairingProd3(
-                Pairing.add(vk_x, proof.A), proof.B,
+                Pairing.addition(vk_x, proof.A), proof.B,
                 Pairing.negate(proof.H), vk.Z,
                 Pairing.negate(proof.C), Pairing.P2()
         )) return 5;
@@ -208,7 +208,7 @@ contract Verifier {
             uint[2] h,
             uint[2] k,
             uint[<%vk_input_length%>] input
-        ) returns (bool r) {
+        ) public returns (bool r) {
         Proof memory proof;
         proof.A = Pairing.G1Point(a[0], a[1]);
         proof.A_p = Pairing.G1Point(a_p[0], a_p[1]);
@@ -223,7 +223,7 @@ contract Verifier {
             inputValues[i] = input[i];
         }
         if (verify(inputValues, proof) == 0) {
-            Verified("Transaction successfully verified.");
+            emit Verified("Transaction successfully verified.");
             return true;
         } else {
             return false;


### PR DESCRIPTION
There are warning in code like
1. `Variable is shadowed in inline assembly by an instruction of the same name`, this is because `Pairing` defines functions with names `add` and `mul` which conflict assembly.
2. `Function state mutability can be restricted to pure`, those functions should be made pure.
3. `Invoking events without "emit" prefix is deprecated.`, logging events should be done by using `emit`
4. `The use of non-functional instructions is deprecated. Please use functional notation instead.`, opcode `invalid` should be used as `invalid()`

Signed-off-by: Lovesh Harchandani <lovesh.bond@gmail.com>