### PR TITLE
Add an importer for .code files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,3 @@ RUN cd libsnark-$libsnarkcommit \
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/lib
 
 COPY . /root/ZoKrates
-
-RUN cd ZoKrates \
-  && cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,6 @@ RUN cd libsnark-$libsnarkcommit \
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/lib
 
 COPY . /root/ZoKrates
+
+RUN cd ZoKrates \
+  && cargo build --release

--- a/examples/imports/bar.code
+++ b/examples/imports/bar.code
@@ -1,0 +1,2 @@
+def main():
+	return 21

--- a/examples/imports/baz.code
+++ b/examples/imports/baz.code
@@ -1,0 +1,2 @@
+def main():
+	return 123

--- a/examples/imports/foo.code
+++ b/examples/imports/foo.code
@@ -1,0 +1,2 @@
+def main():
+	return 42

--- a/examples/imports/foo.code
+++ b/examples/imports/foo.code
@@ -1,2 +1,4 @@
+import "./baz.code"
+
 def main():
-	return 42
+	return baz()

--- a/examples/imports/import.code
+++ b/examples/imports/import.code
@@ -1,6 +1,5 @@
 import "./foo.code"
 import "./bar.code"
 
-
 def main():
-	return 1
+	return foo() + bar()

--- a/examples/imports/import.code
+++ b/examples/imports/import.code
@@ -1,0 +1,4 @@
+import "./foo.code"
+
+def main():
+	return 1

--- a/examples/imports/import.code
+++ b/examples/imports/import.code
@@ -1,4 +1,6 @@
 import "./foo.code"
+import "./bar.code"
+
 
 def main():
 	return 1

--- a/examples/imports/import_with_alias.code
+++ b/examples/imports/import_with_alias.code
@@ -1,0 +1,4 @@
+import "./foo.code" as d
+
+def main():
+	return d()

--- a/src/absy.rs
+++ b/src/absy.rs
@@ -31,19 +31,19 @@ impl<T: Field> Prog<T> {
 
 impl<T: Field> fmt::Display for Prog<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut res = vec![];
+        res.extend(self.imports
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>());
+        res.extend(self.functions
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>());
         write!(
             f,
-            "{}\n{}",
-            self.imports
-                .iter()
-                .map(|x| format!("{}", x))
-                .collect::<Vec<_>>()
-                .join("\n"),
-            self.functions
-                .iter()
-                .map(|x| format!("{}", x))
-                .collect::<Vec<_>>()
-                .join("\n")
+            "{}",
+            res.join("\n")
         )
     }
 }

--- a/src/absy.rs
+++ b/src/absy.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, BTreeMap};
 use field::Field;
 use imports::Import;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct Prog<T: Field> {
     /// Functions of the program
     pub functions: Vec<Function<T>>,
@@ -67,7 +67,7 @@ impl<T: Field> fmt::Debug for Prog<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct Function<T: Field> {
     /// Name of the program
     pub id: String,

--- a/src/absy.rs
+++ b/src/absy.rs
@@ -8,11 +8,13 @@
 use std::fmt;
 use std::collections::{HashMap, BTreeMap};
 use field::Field;
+use imports::Import;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Prog<T: Field> {
     /// Functions of the program
     pub functions: Vec<Function<T>>,
+    pub imports: Vec<Import>
 }
 
 
@@ -31,7 +33,12 @@ impl<T: Field> fmt::Display for Prog<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}",
+            "{}\n{}",
+            self.imports
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>()
+                .join("\n"),
             self.functions
                 .iter()
                 .map(|x| format!("{}", x))
@@ -45,12 +52,17 @@ impl<T: Field> fmt::Debug for Prog<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "program(functions: {}\t)",
+            "program(\n\timports:\n\t\t{}\n\tfunctions:\n\t\t{}\n)",
+            self.imports
+                .iter()
+                .map(|x| format!("{:?}", x))
+                .collect::<Vec<_>>()
+                .join("\n\t\t"),
             self.functions
                 .iter()
-                .map(|x| format!("\t{:?}", x))
+                .map(|x| format!("{:?}", x))
                 .collect::<Vec<_>>()
-                .join("\n")
+                .join("\n\t\t")
         )
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -19,7 +19,12 @@ pub fn compile<T: Field>(path: PathBuf) -> Result<Prog<T>,()> {
 
     let program_ast_without_imports: Prog<T> = parse_program(file, path.to_owned()).unwrap();
 
-    let program_ast = Importer::new().resolve_imports(program_ast_without_imports).unwrap();
+    let compiled_imports: Vec<(Prog<T>, String)> = program_ast_without_imports.clone().imports.into_iter().map(|import| {
+    	let path = import.resolve().unwrap();
+    	(compile(path).unwrap(), import.alias())
+    }).collect();
+    	
+    let program_ast = Importer::new().apply_imports(compiled_imports, program_ast_without_imports);
 
     // check semantics
     Checker::new().check_program(program_ast.clone()).unwrap();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,0 +1,32 @@
+//! Module containing the complete compilation pipeline.
+//!
+//! @file compile.rs
+//! @author Thibaut Schaeffer <thibaut@schaeff.org>
+//! @date 2018
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+use std::string::String;
+use field::{Field, FieldPrime};
+use absy::{Prog};
+use parser::{parse_program, Error};
+use imports::Importer;
+use semantics::Checker;
+use flatten::Flattener;
+
+pub fn compile<T: Field>(path: PathBuf) -> Result<Prog<T>,()> {
+	let file = File::open(&path).unwrap();
+
+    let program_ast_without_imports: Prog<T> = parse_program(file, path.to_owned()).unwrap();
+
+    let program_ast = Importer::new().resolve_imports(program_ast_without_imports).unwrap();
+
+    // check semantics
+    Checker::new().check_program(program_ast.clone()).unwrap();
+
+    // flatten input program
+    let program_flattened =
+        Flattener::new(T::get_required_bits()).flatten_program(program_ast);
+
+    Ok(program_flattened)
+}

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -9,20 +9,48 @@ use std::collections::HashMap;
 use std::string::String;
 use field::{Field, FieldPrime};
 use absy::{Prog};
-use parser::{parse_program, Error};
-use imports::Importer;
-use semantics::Checker;
+use parser::{self, parse_program};
+use imports::{self, Importer};
+use semantics::{self, Checker};
 use flatten::Flattener;
 
-pub fn compile<T: Field>(path: PathBuf) -> Result<Prog<T>,()> {
+#[derive(PartialEq, Debug)]
+pub enum CompileError<T: Field> {
+	ParserError(parser::Error<T>),
+	ImportError(imports::Error),
+	SemanticError(semantics::Error)
+}
+
+impl<T: Field> From<parser::Error<T>> for CompileError<T> {
+	fn from(error: parser::Error<T>) -> Self {
+		CompileError::ParserError(error)
+	}
+}
+
+impl<T: Field> From<imports::Error> for CompileError<T> {
+	fn from(error: imports::Error) -> Self {
+		CompileError::ImportError(error)
+	}
+}
+
+impl<T: Field> From<semantics::Error> for CompileError<T> {
+	fn from(error: semantics::Error) -> Self {
+		CompileError::SemanticError(error)
+	}
+}
+
+pub fn compile<T: Field>(path: PathBuf) -> Result<Prog<T>, CompileError<T>> {
 	let file = File::open(&path).unwrap();
 
     let program_ast_without_imports: Prog<T> = parse_program(file, path.to_owned()).unwrap();
 
-    let compiled_imports: Vec<(Prog<T>, String)> = program_ast_without_imports.clone().imports.into_iter().map(|import| {
-    	let path = import.resolve().unwrap();
-    	(compile(path).unwrap(), import.alias())
-    }).collect();
+    let mut compiled_imports: Vec<(Prog<T>, String)> = vec![];
+
+    for import in program_ast_without_imports.clone().imports {
+    	let path = import.resolve()?;
+    	let compiled = compile(path)?;
+    	compiled_imports.push((compiled, import.alias()));
+    }
     	
     let program_ast = Importer::new().apply_imports(compiled_imports, program_ast_without_imports);
 

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -716,6 +716,7 @@ impl Flattener {
         }
         Prog {
             functions: functions_flattened,
+            imports: vec![]
         }
     }
 

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -969,7 +969,9 @@ mod multiple_definition {
 
         flattener.flatten_program(
             Prog {
-                functions: functions
+                functions: functions,
+                imported_functions: vec![],
+                imports: vec![]
             }
         );
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,0 +1,47 @@
+//! Module containing structs and enums to represent imports.
+//!
+//! @file imports.rs
+//! @author Thibaut Schaeffer <thibaut@schaeff.org>
+//! @date 2018
+
+use std::fmt;
+
+#[derive(PartialEq, Clone, Serialize, Deserialize)]
+pub struct Import {
+	source: String,
+	alias: Option<String>
+}
+
+impl Import {
+	pub fn new(source: String) -> Import {
+		Import {
+			source,
+			alias: None
+		}
+	}
+
+	pub fn new_with_alias(source: String, alias: String) -> Import {
+		Import {
+			source,
+			alias: Some(alias)
+		}
+	}
+}
+
+impl fmt::Display for Import {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match &self.alias {
+			&Some(ref a) => write!(f, "import {} as {}", self.source, a),
+			&None => write!(f, "import {}", self.source)
+		}
+	}
+}
+
+impl fmt::Debug for Import {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match &self.alias {
+			&Some(ref a) => write!(f, "import(source: {}, alias: {})", self.source, a),
+			&None => write!(f, "import(source: {})", self.source)
+		}
+    }
+}

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -48,12 +48,13 @@ impl Import {
 		self.alias.clone()
 	}
 
-	// pub fn new_with_alias(source: String, alias: String) -> Import {
-	// 	Import {
-	// 		source,
-	// 		alias: Some(alias)
-	// 	}
-	// }
+	pub fn new_with_alias(source: String, base: &PathBuf, alias: &String) -> Import {
+		Import {
+			source: PathBuf::from(source.clone()),
+			alias: alias.clone(),
+			base: base.clone()
+		}
+	}
 }
 
 impl fmt::Display for Import {
@@ -107,4 +108,23 @@ impl Importer {
 #[cfg(test)]
 mod tests {
 
+	use super::*;
+
+	#[test]
+	fn create_with_no_alias() {
+		assert_eq!(Import::new("./foo/bar/baz.code".to_string(), &PathBuf::from("/path/to/dir")), Import {
+			source: PathBuf::from("./foo/bar/baz.code"),
+			alias: "baz".to_string(),
+			base: PathBuf::from("/path/to/dir")
+		});
+	}
+
+	#[test]
+	fn create_with_alias() {
+		assert_eq!(Import::new_with_alias("./foo/bar/baz.code".to_string(), &PathBuf::from("/path/to/dir"), &"myalias".to_string()), Import {
+			source: PathBuf::from("./foo/bar/baz.code"),
+			alias: "myalias".to_string(),
+			base: PathBuf::from("/path/to/dir")
+		});
+	}
 }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,7 +1,7 @@
 //! Module containing structs and enums to represent imports.
 //!
 //! @file imports.rs
-//! @author Thibaut Schaeffer <thibaut@schaeff.org>
+//! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2018
 
 use std::fmt;

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -20,12 +20,12 @@ impl Import {
 		}
 	}
 
-	pub fn new_with_alias(source: String, alias: String) -> Import {
-		Import {
-			source,
-			alias: Some(alias)
-		}
-	}
+	// pub fn new_with_alias(source: String, alias: String) -> Import {
+	// 	Import {
+	// 		source,
+	// 		alias: Some(alias)
+	// 	}
+	// }
 }
 
 impl fmt::Display for Import {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -15,6 +15,11 @@ use flatten::Flattener;
 use field::FieldPrime;
 
 
+#[derive(PartialEq, Debug)]
+pub struct Error {
+	message: String
+}
+
 #[derive(PartialEq, Clone, Serialize, Deserialize)]
 pub struct Import {
 	source: PathBuf,
@@ -31,7 +36,7 @@ impl Import {
 		}
 	}
 
-	pub fn resolve(&self) -> Result<PathBuf,String> {
+	pub fn resolve(&self) -> Result<PathBuf,Error> {
 		let mut path = self.base.parent().unwrap().to_owned();
 		let source = self.source.strip_prefix("./").unwrap();
 		path.push(&source);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ use std::string::String;
 use field::{Field, FieldPrime};
 use absy::Prog;
 use parser::parse_program;
+use imports::Importer;
 use semantics::Checker;
 use flatten::Flattener;
 use r1cs::r1cs_program;
@@ -209,12 +210,17 @@ fn main() {
                 Err(why) => panic!("couldn't open {}: {}", path.display(), why),
             };
 
-            let program_ast: Prog<FieldPrime> = match parse_program(file) {
+            let program_ast_without_imports: Prog<FieldPrime> = match parse_program(file, path.to_owned()) {
                 Ok(x) => x,
                 Err(why) => {
                     println!("{:?}", why);
                     std::process::exit(1);
                 }
+            };
+
+            let program_ast = match Importer::new().resolve_imports(program_ast_without_imports) {
+                Ok(program) => program,
+                Err(why) => panic!("Imports failed with {}", why)
             };
 
             println!("{}", program_ast);
@@ -587,7 +593,7 @@ mod tests {
                 Err(why) => panic!("couldn't open {:?}: {}", path, why),
             };
 
-            let program_ast = match parse_program::<FieldPrime>(file) {
+            let program_ast = match parse_program::<FieldPrime>(file, path.to_owned()) {
                 Ok(x) => x,
                 Err(why) => panic!("Error: {:?}", why),
             };
@@ -610,7 +616,7 @@ mod tests {
                 Err(why) => panic!("couldn't open {:?}: {}", path, why),
             };
 
-            let program_ast = match parse_program::<FieldPrime>(file) {
+            let program_ast = match parse_program::<FieldPrime>(file, path.to_owned()) {
                 Ok(x) => x,
                 Err(why) => panic!("Error: {:?}", why),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ extern crate regex;
 
 mod absy;
 mod parser;
+mod imports;
 mod semantics;
 mod flatten;
 mod r1cs;
@@ -215,6 +216,8 @@ fn main() {
                     std::process::exit(1);
                 }
             };
+
+            println!("{}", program_ast);
 
             // check semantics
             match Checker::new().check_program(program_ast.clone()) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1403,7 +1403,7 @@ fn parse_import<T: Field>(
                             }
                         ))
                     },
-                    Some(x) => end += 1,
+                    Some(_) => end += 1,
                     None => {
                         return Err(
                             Error {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,7 +75,7 @@ use std::fmt;
 use std::io::{BufReader, Lines};
 use std::io::prelude::*;
 use std::fs::File;
-use field::{Field, FieldPrime};
+use field::{Field};
 use absy::*;
 use std::path::PathBuf;
 use imports::*;
@@ -165,6 +165,8 @@ enum Token<T: Field> {
     InlineComment(String),
     Import,
     DoubleQuote,
+    Path(String),
+    As,
     // following used for error messages
     ErrIde,
     ErrNum,
@@ -206,6 +208,8 @@ impl<T: Field> fmt::Display for Token<T> {
             Token::InlineComment(ref x) => write!(f, "// {}", x),
             Token::Import => write!(f, "import"),
             Token::DoubleQuote => write!(f, "\""),
+            Token::Path(ref x) => write!(f, "\"{}\"", x),
+            Token::As => write!(f, "as"),
             Token::ErrIde => write!(f, "identifier"),
             Token::ErrNum => write!(f, "number"),
         }
@@ -538,6 +542,14 @@ fn next_token<T: Field>(input: &String, pos: &Position) -> (Token<T>, String, Po
             Position {
                 line: pos.line,
                 col: pos.col + offset + 7
+            }
+        ),
+        Some(_) if input[offset..].starts_with("as ") => (
+            Token::As,
+            input[offset + 2..].to_string(),
+            Position {
+                line: pos.line,
+                col: pos.col + offset + 2
             }
         ),
         Some(x) => match x {
@@ -1385,6 +1397,33 @@ fn parse_function<T: Field>(
     ))
 }
 
+fn parse_quoted_path<T: Field>(
+    input: &String,
+    pos: &Position
+) -> (Token<T>, String, Position) {
+    let mut end = 0;
+    loop {
+        match input.chars().nth(end) {
+            Some(x) => {
+                end += 1;
+                match x {
+                    '\"' => break,
+                    _ => continue,
+                }
+            },
+            None => {
+                panic!("Invalid import path, should end with '\"'")
+            }
+        }
+    }
+    (Token::Path(input[0..end - 1].to_string()),
+    input[end..].to_string(),
+    Position {
+        line: pos.line,
+        col: pos.col + end,
+    })
+}
+
 fn parse_import<T: Field>(
     input: &String,
     pos: &Position,
@@ -1392,39 +1431,55 @@ fn parse_import<T: Field>(
 ) -> Result<(Import, Position), Error<T>> {
     match next_token(input, pos) {
         (Token::DoubleQuote, s1, p1) => {
-            let mut end = 0;
-            loop {
-                match s1.chars().nth(end) {
-                    Some('"') => {
-                        end += 1;
-                        return Ok((
-                            Import::new(s1[0..end - 1].to_string(), &path),
-                            Position {
-                                line: p1.line,
-                                col: p1.col + end
-                            }
-                        ))
-                    },
-                    Some(_) => end += 1,
-                    None => {
-                        return Err(
-                            Error {
-                                expected: vec![Token::DoubleQuote],
-                                got: Token::Unknown("endofline".to_string()),
-                                pos: p1,
-                            }
-                        )
+            match parse_quoted_path(&s1, &p1) {
+                (Token::Path(code_path), s2, p2) => {
+                    match next_token::<T>(&s2, &p2) {
+                        (Token::As, s3, p3) => {
+                            match next_token(&s3, &p3) {
+                                (Token::Ide(id), _, p4) => {
+                                    return Ok((
+                                        Import::new_with_alias(code_path, &path, &id),
+                                        p4
+                                    ))
+                                },
+                                (t4, _, p4) => {
+                                    return Err(
+                                        Error {
+                                            expected: vec![Token::Ide("ide".to_string())],
+                                            got: t4,
+                                            pos: p4
+                                        }
+                                    )
+                                }
+                            } 
+                        },
+                        (Token::Unknown(_), _, p3) => {
+                            return Ok((
+                                Import::new(code_path, &path),
+                                p3
+                            ))
+                        },
+                        (t3, _, p3) => {
+                            return Err( Error {
+                                expected: vec![Token::Ide("id".to_string()), Token::Unknown("".to_string())],
+                                got: t3,
+                                pos: p3
+                            })
+                        }
                     }
-                }
+                },
+                (t2, _, p2) => Err( Error {
+                    expected: vec![Token::Path("./path/to/program.code".to_string())],
+                    got: t2,
+                    pos: p2
+                })
             }
         },
-        (t1, _, p1) => {
-            return Err(Error {
-                expected: vec![Token::DoubleQuote],
-                got: t1,
-                pos: p1,
-            })
-        }
+        (t1, _, p1) => Err( Error {
+            expected: vec![Token::DoubleQuote],
+            got: t1,
+            pos: p1
+        })
     }
 }
 
@@ -1448,7 +1503,7 @@ pub fn parse_program<T: Field>(file: File, path: PathBuf) -> Result<Prog<T>, Err
                 (Token::Import, ref s1, ref p1) => match parse_import(s1, p1, &path) {
                     Ok((import, p2)) => {
                         imports.push(import);
-                        current_line = p2.line; // this is the line of the return statement
+                        current_line = p2.line; // this is the line of the import statement
                         current_line += 1;
                     }
                     Err(err) => return Err(err),
@@ -1485,7 +1540,7 @@ fn parse_comma_separated_expression_list_rec<T: Field>(
     match parse_expr(&input, &pos) {
         Ok((e1, s1, p1)) => {
             acc.expressions.push(e1);
-            match next_token::<FieldPrime>(&s1, &p1) {
+            match next_token::<T>(&s1, &p1) {
                 (Token::Comma, s2, p2) => parse_comma_separated_expression_list_rec(s2, p2, &mut acc),
                 (..) => Ok((acc.clone(), s1, p1)),
             }                
@@ -1502,7 +1557,7 @@ fn parse_comma_separated_identifier_list_rec<T: Field>(
     match next_token(&input, &pos) {
         (Token::Ide(id), s1, p1) => {
             acc.push(id);
-            match next_token::<FieldPrime>(&s1, &p1) {
+            match next_token::<T>(&s1, &p1) {
                 (Token::Comma, s2, p2) => parse_comma_separated_identifier_list_rec(s2, p2, &mut acc),
                 (..) => Ok((acc.to_vec(), s1, p1)),
             }
@@ -1756,14 +1811,25 @@ mod tests {
         use super::*;
 
         #[test]
+        fn quoted_path() {
+            let pos = Position { line: 45, col: 121 };
+            let string = String::from("./foo.code\" as foo");
+            let path: Token<FieldPrime> = Token::Path("./foo.code".to_string());
+            assert_eq!(
+                (path, " as foo".to_string(), pos.col(11 as isize)),
+                parse_quoted_path(&string, &pos)
+            );
+        }
+
+        #[test]
         fn import() {
             let pos = Position { line: 45, col: 121 };
-            let string = String::from("import ./foo.code");
+            let string = String::from("import \"./foo.code\"");
             let import: Token<FieldPrime> = Token::Import;
             assert_eq!(
-                (import, "./foo.code".to_string(), pos.col(7 as isize)),
+                (import, "\"./foo.code\"".to_string(), pos.col(7 as isize)),
                 next_token(&string, &pos)
-            );
+            )
         }
 
         #[test]
@@ -1775,6 +1841,23 @@ mod tests {
             let position = Position {
                 line: 45,
                 col: pos.col + 1 + "./foo.code".len() + 1
+            };
+            assert_eq!(
+                Ok((import, position)),
+                parse_import::<FieldPrime>(&string, &pos, &pathbuf)
+            )
+        }
+
+        #[test]
+        fn parse_import_with_alias_test() {
+            let pos = Position { line: 45, col: 121 };
+            let pathbuf = PathBuf::from("examples/bar.code");
+            let string = String::from("\"./foo.code\" as myalias");
+            let alias = "myalias".to_string();
+            let import = Import::new_with_alias("./foo.code".to_string(), &pathbuf, &alias);
+            let position = Position {
+                line: 45,
+                col: pos.col + string.len()
             };
             assert_eq!(
                 Ok((import, position)),

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -298,7 +298,8 @@ mod tests {
         funcs.push(foo);
         funcs.push(bar);
         let prog = Prog {
-			functions: funcs
+			functions: funcs,
+			imports: vec![]
         };
 
 		let mut checker = Checker::new();
@@ -365,7 +366,8 @@ mod tests {
         funcs.push(bar);
         funcs.push(main);
         let prog = Prog {
-			functions: funcs
+			functions: funcs,
+			imports: vec![]
         };
 
 		let mut checker = Checker::new();
@@ -695,7 +697,8 @@ mod tests {
 		};
 
 		let prog = Prog {
-			functions: vec![main1, main2]
+			functions: vec![main1, main2],
+			imports: vec![]
 		};
 
 		let mut checker = Checker::new();

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -583,7 +583,8 @@ mod tests {
 		};
 
 		let program = Prog {
-			functions: vec![foo, main]
+			functions: vec![foo, main],
+			imports: vec![]
 		};
 
 		let mut checker = new_with_args(HashSet::new(), 0, HashSet::new());


### PR DESCRIPTION
Current syntax:

```
import "./foo.code" as bar

def main():
   return bar(1, 2, 3)
```

To decide:

- [x] How to handle overload? Easiest: forbid overloading for imported functions
- [x] How to handle naming? Easiest: imported file has to have only one exposed function, say `main`. Otherwise we'd have to implement `import <fun> from <file>`. Maybe something for later
- [x] Can we import flattened files to prevent recompiling? Maybe not MVP
- ~[ ] Update grammar in parser~ postponed