### PR TITLE
Split code and flattened code into two types

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -8,6 +8,7 @@ use std::path::{PathBuf};
 use std::fmt;
 use field::{Field, FieldPrime};
 use absy::{Prog};
+use flat_absy::{FlatProg};
 use parser::{self, parse_program};
 use semantics::{self, Checker};
 use flatten::Flattener;
@@ -49,7 +50,7 @@ impl fmt::Display for CompileError<FieldPrime> {
 	}
 }
 
-pub fn compile<T: Field>(path: PathBuf) -> Result<Prog<T>, CompileError<T>> {
+pub fn compile<T: Field>(path: PathBuf) -> Result<FlatProg<T>, CompileError<T>> {
 	let file = File::open(&path)?;
 
     let program_ast: Prog<T> = parse_program(file)?;

--- a/src/flat_absy.rs
+++ b/src/flat_absy.rs
@@ -1,0 +1,333 @@
+//! Module containing structs and enums to represent a program.
+//!
+//! @file absy.rs
+//! @author Dennis Kuhnert <dennis.kuhnert@campus.tu-berlin.de>
+//! @author Jacob Eberhardt <jacob.eberhardt@tu-berlin.de>
+//! @date 2017
+
+use absy::Expression;
+use std::fmt;
+use std::collections::{HashMap, BTreeMap};
+use field::Field;
+use parameter::Parameter;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FlatProg<T: Field> {
+    /// FlatFunctions of the program
+    pub functions: Vec<FlatFunction<T>>,
+}
+
+
+impl<T: Field> FlatProg<T> {
+    // only main flattened function is relevant here, as all other functions are unrolled into it
+    #[allow(dead_code)] // I don't want to remove this
+    pub fn get_witness(&self, inputs: Vec<T>) -> BTreeMap<String, T> {
+        let main = self.functions.iter().find(|x| x.id == "main").unwrap();
+        assert!(main.arguments.len() == inputs.len());
+        main.get_witness(inputs)
+    }
+}
+
+
+impl<T: Field> fmt::Display for FlatProg<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.functions
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+impl<T: Field> fmt::Debug for FlatProg<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "flat_program(functions: {}\t)",
+            self.functions
+                .iter()
+                .map(|x| format!("\t{:?}", x))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FlatFunction<T: Field> {
+    /// Name of the program
+    pub id: String,
+    /// Arguments of the function
+    pub arguments: Vec<Parameter>,
+    /// Vector of statements that are executed when running the function
+    pub statements: Vec<FlatStatement<T>>,
+    /// number of returns
+    pub return_count: usize,
+}
+
+impl<T: Field> FlatFunction<T> {
+    pub fn get_witness(&self, inputs: Vec<T>) -> BTreeMap<String, T> {
+        assert!(self.arguments.len() == inputs.len());
+        let mut witness = BTreeMap::new();
+        witness.insert("~one".to_string(), T::one());
+        for (i, arg) in self.arguments.iter().enumerate() {
+            witness.insert(arg.id.to_string(), inputs[i].clone());
+        }
+        for statement in &self.statements {
+            match *statement {
+                FlatStatement::Return(ref list) => {
+                    for (i, val) in list.expressions.iter().enumerate() {
+                        let s = val.solve(&mut witness);
+                        witness.insert(format!("~out_{}", i).to_string(), s);
+                    }
+                }
+                FlatStatement::Definition(ref id, ref expr) => {
+                    let s = expr.solve(&mut witness);
+                    witness.insert(id.to_string(), s);
+                },
+                FlatStatement::Compiler(ref id, ref expr) => {
+                    let s = expr.solve(&mut witness);
+                    witness.insert(id.to_string(), s);
+                },
+                FlatStatement::Condition(ref lhs, ref rhs) => {
+                    assert_eq!(lhs.solve(&mut witness), rhs.solve(&mut witness))
+                }
+            }
+        }
+        witness
+    }
+}
+
+impl<T: Field> fmt::Display for FlatFunction<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "def {}({}):\n{}",
+            self.id,
+            self.arguments
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>()
+                .join(","),
+            self.statements
+                .iter()
+                .map(|x| format!("\t{}", x))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+impl<T: Field> fmt::Debug for FlatFunction<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FlatFunction(id: {:?}, arguments: {:?}, ...):\n{}",
+            self.id,
+            self.arguments,
+            self.statements
+                .iter()
+                .map(|x| format!("\t{:?}", x))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
+pub enum FlatStatement<T: Field> {
+    Return(FlatExpressionList<T>),
+    Condition(FlatExpression<T>, FlatExpression<T>),
+    Compiler(String, Expression<T>),
+    Definition(String, FlatExpression<T>)
+}
+
+impl<T: Field> fmt::Display for FlatStatement<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FlatStatement::Definition(ref lhs, ref rhs) => write!(f, "{} = {}", lhs, rhs),
+            FlatStatement::Return(ref expr) => write!(f, "return {}", expr),
+            FlatStatement::Condition(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
+            FlatStatement::Compiler(ref lhs, ref rhs) => write!(f, "# {} = {}", lhs, rhs),
+        }
+    }
+}
+
+impl<T: Field> fmt::Debug for FlatStatement<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FlatStatement::Definition(ref lhs, ref rhs) => write!(f, "{} = {}", lhs, rhs),
+            FlatStatement::Return(ref expr) => write!(f, "FlatReturn({:?})", expr),
+            FlatStatement::Condition(ref lhs, ref rhs) => write!(f, "FlatCondition({:?}, {:?})", lhs, rhs),
+            FlatStatement::Compiler(ref lhs, ref rhs) => write!(f, "Compiler({:?}, {:?})", lhs, rhs),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub enum FlatExpression<T: Field> {
+    Number(T),
+    Identifier(String),
+    Add(Box<FlatExpression<T>>, Box<FlatExpression<T>>),
+    Sub(Box<FlatExpression<T>>, Box<FlatExpression<T>>),
+    Div(Box<FlatExpression<T>>, Box<FlatExpression<T>>),
+    Mult(Box<FlatExpression<T>>, Box<FlatExpression<T>>)
+}
+
+impl<T: Field> FlatExpression<T> {
+    pub fn apply_substitution(&self, substitution: &HashMap<String, String>) -> FlatExpression<T> {
+        match *self {
+            ref e @ FlatExpression::Number(_) => e.clone(),
+            FlatExpression::Identifier(ref v) => {
+                let mut new_name = v.to_string();
+                loop {
+                    match substitution.get(&new_name) {
+                        Some(x) => new_name = x.to_string(),
+                        None => return FlatExpression::Identifier(new_name),
+                    }
+                }
+            }
+            FlatExpression::Add(ref e1, ref e2) => FlatExpression::Add(
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
+            ),
+            FlatExpression::Sub(ref e1, ref e2) => FlatExpression::Sub(
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
+            ),
+            FlatExpression::Mult(ref e1, ref e2) => FlatExpression::Mult(
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
+            ),
+            FlatExpression::Div(ref e1, ref e2) => FlatExpression::Div(
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
+            )
+
+        }
+    }
+
+    fn solve(&self, inputs: &mut BTreeMap<String, T>) -> T {
+        match *self {
+            FlatExpression::Number(ref x) => x.clone(),
+            FlatExpression::Identifier(ref var) => {
+                if let None = inputs.get(var) {
+                    if var.contains("_b") {
+                        let var_name = var.split("_b").collect::<Vec<_>>()[0];
+                        let mut num = inputs[var_name].clone();
+                        let bits = T::get_required_bits();
+                        for i in (0..bits).rev() {
+                            if T::from(2).pow(i) <= num {
+                                num = num - T::from(2).pow(i);
+                                inputs.insert(format!("{}_b{}", &var_name, i), T::one());
+                            } else {
+                                inputs.insert(format!("{}_b{}", &var_name, i), T::zero());
+                            }
+                        }
+                        assert_eq!(num, T::zero());
+                    } else {
+                        panic!(
+                            "Variable {:?} is undeclared in inputs: {:?}",
+                            var,
+                            inputs
+                        );
+                    }
+                }
+                inputs[var].clone()
+            }
+            FlatExpression::Add(ref x, ref y) => x.solve(inputs) + y.solve(inputs),
+            FlatExpression::Sub(ref x, ref y) => x.solve(inputs) - y.solve(inputs),
+            FlatExpression::Mult(ref x, ref y) => x.solve(inputs) * y.solve(inputs),
+            FlatExpression::Div(ref x, ref y) => x.solve(inputs) / y.solve(inputs),
+        }
+    }
+
+    pub fn is_linear(&self) -> bool {
+        match *self {
+            FlatExpression::Number(_) | FlatExpression::Identifier(_) => true,
+            FlatExpression::Add(ref x, ref y) | FlatExpression::Sub(ref x, ref y) => {
+                x.is_linear() && y.is_linear()
+            }
+            FlatExpression::Mult(ref x, ref y) | FlatExpression::Div(ref x, ref y) => {
+                match (x.clone(), y.clone()) {
+                    (box FlatExpression::Number(_), box FlatExpression::Number(_)) |
+                    (box FlatExpression::Number(_), box FlatExpression::Identifier(_)) |
+                    (box FlatExpression::Identifier(_), box FlatExpression::Number(_)) => true,
+                    _ => false,
+                }
+            }
+        }
+    }
+}
+
+impl<T: Field> fmt::Display for FlatExpression<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FlatExpression::Number(ref i) => write!(f, "{}", i),
+            FlatExpression::Identifier(ref var) => write!(f, "{}", var),
+            FlatExpression::Add(ref lhs, ref rhs) => write!(f, "({} + {})", lhs, rhs),
+            FlatExpression::Sub(ref lhs, ref rhs) => write!(f, "({} - {})", lhs, rhs),
+            FlatExpression::Mult(ref lhs, ref rhs) => write!(f, "({} * {})", lhs, rhs),
+            FlatExpression::Div(ref lhs, ref rhs) => write!(f, "({} / {})", lhs, rhs),
+        }
+    }
+}
+
+impl<T: Field> fmt::Debug for FlatExpression<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FlatExpression::Number(ref i) => write!(f, "Num({})", i),
+            FlatExpression::Identifier(ref var) => write!(f, "Ide({})", var),
+            FlatExpression::Add(ref lhs, ref rhs) => write!(f, "Add({:?}, {:?})", lhs, rhs),
+            FlatExpression::Sub(ref lhs, ref rhs) => write!(f, "Sub({:?}, {:?})", lhs, rhs),
+            FlatExpression::Mult(ref lhs, ref rhs) => write!(f, "Mult({:?}, {:?})", lhs, rhs),
+            FlatExpression::Div(ref lhs, ref rhs) => write!(f, "Div({:?}, {:?})", lhs, rhs),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct FlatExpressionList<T: Field> {
+    pub expressions: Vec<FlatExpression<T>>
+}
+
+impl<T: Field> fmt::Display for FlatExpressionList<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (i, param) in self.expressions.iter().enumerate() {
+            try!(write!(f, "{}", param));
+            if i < self.expressions.len() - 1 {
+                try!(write!(f, ", "));
+            }
+        }
+        write!(f, "")
+    }
+}
+
+impl<T: Field> fmt::Debug for FlatExpressionList<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ExpressionList({:?})", self.expressions)
+    }
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub enum FlatCondition<T: Field> {
+    Eq(FlatExpression<T>, FlatExpression<T>),
+}
+
+impl<T: Field> fmt::Display for FlatCondition<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FlatCondition::Eq(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
+        }
+    }
+}
+
+impl<T: Field> fmt::Debug for FlatCondition<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -326,14 +326,18 @@ impl Flattener {
                     statements_flattened,
                     right,
                 );
-                let new_left = {
+                let new_left = if left_flattened.is_linear() {
+                    left_flattened
+                } else {
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
                         .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
                     FlatExpression::Identifier(new_name)
                 };
-                let new_right = {
+                let new_right = if right_flattened.is_linear() {
+                    right_flattened
+                } else {
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
@@ -355,14 +359,18 @@ impl Flattener {
                     statements_flattened,
                     right,
                 );
-                let new_left = {
+                let new_left = if left_flattened.is_linear() {
+                    left_flattened
+                } else {                    
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
                         .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
                     FlatExpression::Identifier(new_name)
                 };
-                let new_right = {
+                let new_right = if right_flattened.is_linear() {
+                    right_flattened
+                } else {                    
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -7,8 +7,9 @@
 
 use std::collections::{HashMap, HashSet};
 use absy::*;
-use absy::Expression::*;
 use field::Field;
+use flat_absy::*;
+use parameter::Parameter;
 
 /// Flattener, computes flattened program.
 pub struct Flattener {
@@ -49,9 +50,9 @@ impl Flattener {
     /// * `condition` - `Condition` that will be flattened.
     fn flatten_condition<T: Field>(
         &mut self,
-        functions_flattened: &Vec<Function<T>>,
+        functions_flattened: &Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<Parameter>,
-        statements_flattened: &mut Vec<Statement<T>>,
+        statements_flattened: &mut Vec<FlatStatement<T>>,
         condition: Condition<T>,
     ) -> (Expression<T>, Expression<T>) {
         match condition {
@@ -72,73 +73,73 @@ impl Flattener {
                 let lhs_name = format!("sym_{}", self.next_var_idx);
                 self.next_var_idx += 1;
                 statements_flattened
-                    .push(Statement::Definition(lhs_name.to_string(), lhs_flattened));
+                    .push(FlatStatement::Definition(lhs_name.to_string(), lhs_flattened));
                 let rhs_name = format!("sym_{}", self.next_var_idx);
                 self.next_var_idx += 1;
                 statements_flattened
-                    .push(Statement::Definition(rhs_name.to_string(), rhs_flattened));
+                    .push(FlatStatement::Definition(rhs_name.to_string(), rhs_flattened));
 
                 let subtraction_result = format!("sym_{}", self.next_var_idx);
                 self.next_var_idx += 1;
-                statements_flattened.push(Statement::Definition(
+                statements_flattened.push(FlatStatement::Definition(
                     subtraction_result.to_string(),
-                    Sub(
-                        box Mult(box Number(T::from(2)), box Identifier(lhs_name.to_string())),
-                        box Mult(box Number(T::from(2)), box Identifier(rhs_name.to_string())),
+                    FlatExpression::Sub(
+                        box FlatExpression::Mult(box FlatExpression::Number(T::from(2)), box FlatExpression::Identifier(lhs_name.to_string())),
+                        box FlatExpression::Mult(box FlatExpression::Number(T::from(2)), box FlatExpression::Identifier(rhs_name.to_string())),
                     ),
                 ));
                 for i in 0..self.bits - 2 {
                     let new_name = format!("{}_b{}", &subtraction_result, i);
-                    statements_flattened.push(Statement::Definition(
+                    statements_flattened.push(FlatStatement::Definition(
                         new_name.to_string(),
-                        Mult(
-                            box Identifier(new_name.to_string()),
-                            box Identifier(new_name.to_string()),
+                        FlatExpression::Mult(
+                            box FlatExpression::Identifier(new_name.to_string()),
+                            box FlatExpression::Identifier(new_name.to_string()),
                         ),
                     ));
                 }
-                let mut expr = Add(
-                    box Identifier(format!("{}_b0", &subtraction_result)), // * 2^0
-                    box Mult(
-                        box Identifier(format!("{}_b1", &subtraction_result)),
-                        box Number(T::from(2)),
+                let mut expr = FlatExpression::Add(
+                    box FlatExpression::Identifier(format!("{}_b0", &subtraction_result)), // * 2^0
+                    box FlatExpression::Mult(
+                        box FlatExpression::Identifier(format!("{}_b1", &subtraction_result)),
+                        box FlatExpression::Number(T::from(2)),
                     ),
                 );
                 for i in 1..self.bits / 2 {
-                    expr = Add(
+                    expr = FlatExpression::Add(
                         box expr,
-                        box Add(
-                            box Mult(
-                                box Identifier(format!("{}_b{}", &subtraction_result, 2 * i)),
-                                box Number(T::from(2).pow(2 * i)),
+                        box FlatExpression::Add(
+                            box FlatExpression::Mult(
+                                box FlatExpression::Identifier(format!("{}_b{}", &subtraction_result, 2 * i)),
+                                box FlatExpression::Number(T::from(2).pow(2 * i)),
                             ),
-                            box Mult(
-                                box Identifier(format!("{}_b{}", &subtraction_result, 2 * i + 1)),
-                                box Number(T::from(2).pow(2 * i + 1)),
+                            box FlatExpression::Mult(
+                                box FlatExpression::Identifier(format!("{}_b{}", &subtraction_result, 2 * i + 1)),
+                                box FlatExpression::Number(T::from(2).pow(2 * i + 1)),
                             ),
                         ),
                     );
                 }
                 if self.bits % 2 == 1 {
-                    expr = Add(
+                    expr = FlatExpression::Add(
                         box expr,
-                        box Mult(
-                            box Identifier(format!("{}_b{}", &subtraction_result, self.bits - 3)),
-                            box Number(T::from(2).pow(self.bits - 1)),
+                        box FlatExpression::Mult(
+                            box FlatExpression::Identifier(format!("{}_b{}", &subtraction_result, self.bits - 3)),
+                            box FlatExpression::Number(T::from(2).pow(self.bits - 1)),
                         ),
                     )
                 }
                 statements_flattened
-                    .push(Statement::Definition(subtraction_result.to_string(), expr));
+                    .push(FlatStatement::Definition(subtraction_result.to_string(), expr));
 
                 let cond_true = format!("{}_b0", &subtraction_result);
                 let cond_false = format!("sym_{}", self.next_var_idx);
                 self.next_var_idx += 1;
-                statements_flattened.push(Statement::Definition(
+                statements_flattened.push(FlatStatement::Definition(
                     cond_false.to_string(),
-                    Sub(box Number(T::one()), box Identifier(cond_true.to_string())),
+                    FlatExpression::Sub(box FlatExpression::Number(T::one()), box FlatExpression::Identifier(cond_true.to_string())),
                 ));
-                (Identifier(cond_true), Identifier(cond_false))
+                (Expression::Identifier(cond_true), Expression::Identifier(cond_false))
             }
             Condition::Eq(lhs, rhs) => {
                 // Wanted: (Y = (X != 0) ? 1 : 0)
@@ -160,39 +161,39 @@ impl Flattener {
                     functions_flattened,
                     arguments_flattened,
                     statements_flattened,
-                    Sub(box lhs, box rhs),
+                    Expression::Sub(box lhs, box rhs),
                 );
-                statements_flattened.push(Statement::Definition(name_x.to_string(), x));
-                statements_flattened.push(Statement::Compiler(
+                statements_flattened.push(FlatStatement::Definition(name_x.to_string(), x));
+                statements_flattened.push(FlatStatement::Compiler(
                     name_y.to_string(),
-                    IfElse(
-                        box Condition::Eq(Identifier(name_x.to_string()), Number(T::zero())),
-                        box Number(T::zero()),
-                        box Number(T::one()),
+                    Expression::IfElse(
+                            box Condition::Eq(Expression::Identifier(name_x.to_string()), Expression::Number(T::zero())),
+                            box Expression::Number(T::zero()),
+                            box Expression::Number(T::one()),
                     ),
                 ));
-                statements_flattened.push(Statement::Compiler(
+                statements_flattened.push(FlatStatement::Compiler(
                     name_m.to_string(),
-                    IfElse(
-                        box Condition::Eq(Identifier(name_x.to_string()), Number(T::zero())),
-                        box Number(T::one()),
-                        box Div(box Number(T::one()), box Identifier(name_x.to_string())),
+                    Expression::IfElse(
+                            box Condition::Eq(Expression::Identifier(name_x.to_string()), Expression::Number(T::zero())),
+                            box Expression::Number(T::one()),
+                            box Expression::Div(box Expression::Number(T::one()), box Expression::Identifier(name_x.to_string())),
                     ),
                 ));
-                statements_flattened.push(Statement::Condition(
-                    Identifier(name_y.to_string()),
-                    Mult(box Identifier(name_x.to_string()), box Identifier(name_m)),
+                statements_flattened.push(FlatStatement::Condition(
+                    FlatExpression::Identifier(name_y.to_string()),
+                    FlatExpression::Mult(box FlatExpression::Identifier(name_x.to_string()), box FlatExpression::Identifier(name_m)),
                 ));
-                statements_flattened.push(Statement::Definition(
+                statements_flattened.push(FlatStatement::Definition(
                     name_1_y.to_string(),
-                    Sub(box Number(T::one()), box Identifier(name_y.to_string())),
+                    FlatExpression::Sub(box FlatExpression::Number(T::one()), box FlatExpression::Identifier(name_y.to_string())),
                 ));
-                statements_flattened.push(Statement::Condition(
-                    Number(T::zero()),
-                    Mult(box Identifier(name_1_y.to_string()), box Identifier(name_x)),
+                statements_flattened.push(FlatStatement::Condition(
+                    FlatExpression::Number(T::zero()),
+                    FlatExpression::Mult(box FlatExpression::Identifier(name_1_y.to_string()), box FlatExpression::Identifier(name_x)),
                 ));
 
-                (Identifier(name_1_y), Identifier(name_y))
+                (Expression::Identifier(name_1_y), Expression::Identifier(name_y))
             }
             _ => unimplemented!(),
         }
@@ -200,12 +201,12 @@ impl Flattener {
 
     fn flatten_function_call<T: Field>(
         &mut self,
-        functions_flattened: &Vec<Function<T>>,
+        functions_flattened: &Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<Parameter>,
-        statements_flattened: &mut Vec<Statement<T>>,
+        statements_flattened: &mut Vec<FlatStatement<T>>,
         id: &String,
         param_expressions: &Vec<Expression<T>>
-    ) -> ExpressionList<T> {
+    ) -> FlatExpressionList<T> {
         for funct in functions_flattened {
             if funct.id == *id && funct.arguments.len() == (*param_expressions).len() {
                 // funct is now the called function
@@ -236,7 +237,7 @@ impl Flattener {
                         Expression::Identifier(ref x) => {
                             new_var = format!("{}param_{}", &prefix, i);
                                 statements_flattened
-                                .push(Statement::Definition(new_var.clone(), Expression::Identifier(x.clone().to_string())));
+                                .push(FlatStatement::Definition(new_var.clone(), FlatExpression::Identifier(x.clone().to_string())));
                         },
                         _ => {
                             let expr_subbed = param_expr.apply_substitution(&self.substitution);
@@ -248,7 +249,7 @@ impl Flattener {
                             );
                             new_var = format!("{}param_{}", &prefix, i);
                             statements_flattened
-                                .push(Statement::Definition(new_var.clone(), rhs));
+                                .push(FlatStatement::Definition(new_var.clone(), rhs));
                         }
                     }
                     replacement_map.insert(funct.arguments.get(i).unwrap().id.clone(), new_var);
@@ -257,35 +258,33 @@ impl Flattener {
                 // Ensure Renaming and correct returns:
                 // add all flattened statements, adapt return statement
                 for stat in funct.statements.clone() {
-                    assert!(stat.is_flattened(), format!("Not flattened: {}", &stat));
                     match stat {
                         // set return statements right side as expression result
-                        Statement::Return(list) => {
-                            return ExpressionList {
+                        FlatStatement::Return(list) => {
+                            return FlatExpressionList {
                                 expressions: list.expressions.into_iter().map(|x| x.apply_substitution(&replacement_map)).collect()
                             }
                         },
-                        Statement::Definition(var, rhs) => {
+                        FlatStatement::Definition(var, rhs) => {
                             let new_rhs = rhs.apply_substitution(&replacement_map);
                             let new_var: String = format!("{}{}", prefix, var.clone());
                             replacement_map.insert(var, new_var.clone());
                             statements_flattened.push(
-                                Statement::Definition(new_var, new_rhs)
+                                FlatStatement::Definition(new_var, new_rhs)
                             );
                         },
-                        Statement::Compiler(var, rhs) => {
+                        FlatStatement::Compiler(var, rhs) => {
                             let new_rhs = rhs.apply_substitution(&replacement_map);
                             let new_var: String = format!("{}{}", prefix, var.clone());
                             replacement_map.insert(var, new_var.clone());
-                            statements_flattened.push(Statement::Compiler(new_var, new_rhs));
+                            statements_flattened.push(FlatStatement::Compiler(new_var, new_rhs));
                         },
-                        Statement::Condition(lhs, rhs) => {
+                        FlatStatement::Condition(lhs, rhs) => {
                             let new_lhs = lhs.apply_substitution(&replacement_map);
                             let new_rhs = rhs.apply_substitution(&replacement_map);
                             statements_flattened
-                                .push(Statement::Condition(new_lhs, new_rhs));
-                        },
-                        _ => panic!("Statement inside function not flattened when flattening function call")
+                                .push(FlatStatement::Condition(new_lhs, new_rhs));
+                        }
                     }
                 }
             }
@@ -306,19 +305,73 @@ impl Flattener {
     /// * `expr` - `Expresstion` that will be flattened.
     fn flatten_expression<T: Field>(
         &mut self,
-        functions_flattened: &Vec<Function<T>>,
+        functions_flattened: &Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<Parameter>,
-        statements_flattened: &mut Vec<Statement<T>>,
+        statements_flattened: &mut Vec<FlatStatement<T>>,
         expr: Expression<T>,
-    ) -> Expression<T> {
+    ) -> FlatExpression<T> {
         match expr {
-            x @ Number(_) | x @ Identifier(_) => x,
-            ref x @ Add(..) | ref x @ Sub(..) | ref x @ Mult(..) | ref x @ Div(..)
-                if x.is_flattened() =>
-            {
-                x.clone()
+            Expression::Number(x) => FlatExpression::Number(x),
+            Expression::Identifier(x) => FlatExpression::Identifier(x),
+            Expression::Add(box left, box right) => {
+                let left_flattened = self.flatten_expression(
+                    functions_flattened,
+                    arguments_flattened,
+                    statements_flattened,
+                    left,
+                );
+                let right_flattened = self.flatten_expression(
+                    functions_flattened,
+                    arguments_flattened,
+                    statements_flattened,
+                    right,
+                );
+                let new_left = {
+                    let new_name = format!("sym_{}", self.next_var_idx);
+                    self.next_var_idx += 1;
+                    statements_flattened
+                        .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
+                    FlatExpression::Identifier(new_name)
+                };
+                let new_right = {
+                    let new_name = format!("sym_{}", self.next_var_idx);
+                    self.next_var_idx += 1;
+                    statements_flattened
+                        .push(FlatStatement::Definition(new_name.to_string(), right_flattened));
+                    FlatExpression::Identifier(new_name)
+                };
+                FlatExpression::Add(box new_left, box new_right)
             }
-            Add(box left, box right) => {
+            Expression::Sub(box left, box right) => {
+                let left_flattened = self.flatten_expression(
+                    functions_flattened,
+                    arguments_flattened,
+                    statements_flattened,
+                    left,
+                );
+                let right_flattened = self.flatten_expression(
+                    functions_flattened,
+                    arguments_flattened,
+                    statements_flattened,
+                    right,
+                );
+                let new_left = {
+                    let new_name = format!("sym_{}", self.next_var_idx);
+                    self.next_var_idx += 1;
+                    statements_flattened
+                        .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
+                    FlatExpression::Identifier(new_name)
+                };
+                let new_right = {
+                    let new_name = format!("sym_{}", self.next_var_idx);
+                    self.next_var_idx += 1;
+                    statements_flattened
+                        .push(FlatStatement::Definition(new_name.to_string(), right_flattened));
+                    FlatExpression::Identifier(new_name)
+                };
+                FlatExpression::Sub(box new_left, box new_right)
+            }
+            Expression::Mult(box left, box right) => {
                 let left_flattened = self.flatten_expression(
                     functions_flattened,
                     arguments_flattened,
@@ -332,78 +385,12 @@ impl Flattener {
                     right,
                 );
                 let new_left = if left_flattened.is_linear() {
-                    left_flattened
-                } else {
-                    let new_name = format!("sym_{}", self.next_var_idx);
-                    self.next_var_idx += 1;
-                    statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), left_flattened));
-                    Identifier(new_name)
-                };
-                let new_right = if right_flattened.is_linear() {
-                    right_flattened
-                } else {
-                    let new_name = format!("sym_{}", self.next_var_idx);
-                    self.next_var_idx += 1;
-                    statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), right_flattened));
-                    Identifier(new_name)
-                };
-                Add(box new_left, box new_right)
-            }
-            Sub(box left, box right) => {
-                let left_flattened = self.flatten_expression(
-                    functions_flattened,
-                    arguments_flattened,
-                    statements_flattened,
-                    left,
-                );
-                let right_flattened = self.flatten_expression(
-                    functions_flattened,
-                    arguments_flattened,
-                    statements_flattened,
-                    right,
-                );
-                let new_left = if left_flattened.is_linear() {
-                    left_flattened
-                } else {
-                    let new_name = format!("sym_{}", self.next_var_idx);
-                    self.next_var_idx += 1;
-                    statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), left_flattened));
-                    Identifier(new_name)
-                };
-                let new_right = if right_flattened.is_linear() {
-                    right_flattened
-                } else {
-                    let new_name = format!("sym_{}", self.next_var_idx);
-                    self.next_var_idx += 1;
-                    statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), right_flattened));
-                    Identifier(new_name)
-                };
-                Sub(box new_left, box new_right)
-            }
-            Mult(box left, box right) => {
-                let left_flattened = self.flatten_expression(
-                    functions_flattened,
-                    arguments_flattened,
-                    statements_flattened,
-                    left,
-                );
-                let right_flattened = self.flatten_expression(
-                    functions_flattened,
-                    arguments_flattened,
-                    statements_flattened,
-                    right,
-                );
-                let new_left = if left_flattened.is_linear() {
-                    if let Sub(..) = left_flattened {
+                    if let FlatExpression::Sub(..) = left_flattened {
                         let new_name = format!("sym_{}", self.next_var_idx);
                         self.next_var_idx += 1;
                         statements_flattened
-                            .push(Statement::Definition(new_name.to_string(), left_flattened));
-                        Identifier(new_name)
+                            .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
+                        FlatExpression::Identifier(new_name)
                     } else {
                         left_flattened
                     }
@@ -411,16 +398,16 @@ impl Flattener {
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), left_flattened));
-                    Identifier(new_name)
+                        .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
+                    FlatExpression::Identifier(new_name)
                 };
                 let new_right = if right_flattened.is_linear() {
-                    if let Sub(..) = right_flattened {
+                    if let FlatExpression::Sub(..) = right_flattened {
                         let new_name = format!("sym_{}", self.next_var_idx);
                         self.next_var_idx += 1;
                         statements_flattened
-                            .push(Statement::Definition(new_name.to_string(), right_flattened));
-                        Identifier(new_name)
+                            .push(FlatStatement::Definition(new_name.to_string(), right_flattened));
+                        FlatExpression::Identifier(new_name)
                     } else {
                         right_flattened
                     }
@@ -428,12 +415,12 @@ impl Flattener {
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), right_flattened));
-                    Identifier(new_name)
+                        .push(FlatStatement::Definition(new_name.to_string(), right_flattened));
+                    FlatExpression::Identifier(new_name)
                 };
-                Mult(box new_left, box new_right)
+                FlatExpression::Mult(box new_left, box new_right)
             }
-            Div(box left, box right) => {
+            Expression::Div(box left, box right) => {
                 let left_flattened = self.flatten_expression(
                     functions_flattened,
                     arguments_flattened,
@@ -446,62 +433,59 @@ impl Flattener {
                     statements_flattened,
                     right,
                 );
-                let new_left = if left_flattened.is_linear() {
-                    left_flattened
-                } else {
+                let new_left = {
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), left_flattened));
-                    Identifier(new_name)
+                        .push(FlatStatement::Definition(new_name.to_string(), left_flattened));
+                    FlatExpression::Identifier(new_name)
                 };
-                let new_right = if right_flattened.is_linear() {
-                    right_flattened
-                } else {
+                let new_right = {
                     let new_name = format!("sym_{}", self.next_var_idx);
                     self.next_var_idx += 1;
                     statements_flattened
-                        .push(Statement::Definition(new_name.to_string(), right_flattened));
-                    Identifier(new_name)
+                        .push(FlatStatement::Definition(new_name.to_string(), right_flattened));
+                    FlatExpression::Identifier(new_name)
                 };
-                Div(box new_left, box new_right)
+                FlatExpression::Div(box new_left, box new_right)
             }
-            Pow(base, exponent) => {
+            Expression::Pow(base, exponent) => {
                 // TODO currently assuming that base is number or variable
                 match exponent {
-                    box Number(ref x) if x > &T::one() => match base {
-                        box Identifier(ref var) => {
+                    box Expression::Number(ref x) if x > &T::one() => match base {
+                        box Expression::Identifier(ref var) => {
                             let id = if x > &T::from(2) {
                                 let tmp_expression = self.flatten_expression(
                                     functions_flattened,
                                     arguments_flattened,
                                     statements_flattened,
-                                    Pow(
-                                        box Identifier(var.to_string()),
-                                        box Number(x.clone() - T::one()),
+                                    Expression::Pow(
+                                        box Expression::Identifier(var.to_string()),
+                                        box Expression::Number(x.clone() - T::one()),
                                     ),
                                 );
                                 let new_name = format!("sym_{}", self.next_var_idx);
                                 self.next_var_idx += 1;
                                 statements_flattened.push(
-                                    Statement::Definition(new_name.to_string(), tmp_expression),
+                                    FlatStatement::Definition(new_name.to_string(), tmp_expression),
                                 );
                                 new_name
                             } else {
                                 var.to_string()
                             };
-                            Mult(
-                                box Identifier(id.to_string()),
-                                box Identifier(var.to_string()),
+                            FlatExpression::Mult(
+                                box FlatExpression::Identifier(id.to_string()),
+                                box FlatExpression::Identifier(var.to_string()),
                             )
                         }
-                        box Number(var) => Mult(box Number(var.clone()), box Number(var)),
+                        box Expression::Number(var) => FlatExpression::Mult(box FlatExpression::Number(var.clone()), box FlatExpression::Number(var)),
                         _ => panic!("Only variables and numbers allowed in pow base"),
                     },
                     _ => panic!("Expected number > 1 as pow exponent"),
                 }
             }
-            IfElse(box condition, consequent, alternative) => {
+            Expression::IfElse(box condition, consequent, alternative) => {
+
                 let (cond_true, cond_false) = self.flatten_condition(
                     functions_flattened,
                     arguments_flattened,
@@ -513,13 +497,13 @@ impl Flattener {
                     functions_flattened,
                     arguments_flattened,
                     statements_flattened,
-                    Add(
-                        box Mult(box cond_true, consequent),
-                        box Mult(box cond_false, alternative),
+                    Expression::Add(
+                        box Expression::Mult(box cond_true, consequent),
+                        box Expression::Mult(box cond_false, alternative),
                     ),
                 )
             }
-            FunctionCall(ref id, ref param_expressions) => {
+            Expression::FunctionCall(ref id, ref param_expressions) => {
                 let exprs_flattened = self.flatten_function_call(
                     functions_flattened,
                     arguments_flattened,
@@ -535,11 +519,11 @@ impl Flattener {
 
     pub fn flatten_expression_list<T: Field>(
         &mut self,
-        functions_flattened: &mut Vec<Function<T>>,
+        functions_flattened: &mut Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<Parameter>,
-        statements_flattened: &mut Vec<Statement<T>>,
+        statements_flattened: &mut Vec<FlatStatement<T>>,
         list: ExpressionList<T>,
-    ) -> ExpressionList<T> {
+    ) -> FlatExpressionList<T> {
         let flattened_exprs = list.expressions.into_iter().map(|x| 
             self.flatten_expression(
                 functions_flattened, 
@@ -547,16 +531,16 @@ impl Flattener {
                 statements_flattened, 
                 x.clone())
             ).collect();
-        ExpressionList {
+        FlatExpressionList {
             expressions: flattened_exprs
         }
     }
 
     pub fn flatten_statement<T: Field>(
         &mut self,
-        functions_flattened: &mut Vec<Function<T>>,
+        functions_flattened: &mut Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<Parameter>,
-        statements_flattened: &mut Vec<Statement<T>>,
+        statements_flattened: &mut Vec<FlatStatement<T>>,
         stat: &Statement<T>,
     ) {
         match *stat {
@@ -569,7 +553,7 @@ impl Flattener {
                     exprs_subbed,
                 );
                 
-                statements_flattened.push(Statement::Return(rhs));
+                statements_flattened.push(FlatStatement::Return(rhs));
             }
             Statement::Definition(ref id, ref expr) => {
                 let expr_subbed = expr.apply_substitution(&self.substitution);
@@ -586,14 +570,19 @@ impl Flattener {
                     self.substitution.insert(var_to_replace.clone().to_string(),var.clone());
                 }
 
-                statements_flattened.push(Statement::Definition(var, rhs));
+                statements_flattened.push(FlatStatement::Definition(var, rhs));
             }
             Statement::Condition(ref expr1, ref expr2) => {
                 let expr1_subbed = expr1.apply_substitution(&self.substitution);
                 let expr2_subbed = expr2.apply_substitution(&self.substitution);
                 let (lhs, rhs) = if expr1_subbed.is_linear() {
                     (
-                        expr1_subbed,
+                        self.flatten_expression(
+                            functions_flattened,
+                            arguments_flattened,
+                            statements_flattened,
+                            expr1_subbed
+                        ),
                         self.flatten_expression(
                             functions_flattened,
                             arguments_flattened,
@@ -603,7 +592,12 @@ impl Flattener {
                     )
                 } else if expr2_subbed.is_linear() {
                     (
-                        expr2_subbed,
+                        self.flatten_expression(
+                            functions_flattened,
+                            arguments_flattened,
+                            statements_flattened,
+                            expr2_subbed,
+                        ),
                         self.flatten_expression(
                             functions_flattened,
                             arguments_flattened,
@@ -614,14 +608,14 @@ impl Flattener {
                 } else {
                     unimplemented!()
                 };
-                statements_flattened.push(Statement::Condition(lhs, rhs));
+                statements_flattened.push(FlatStatement::Condition(lhs, rhs));
             }
             Statement::For(ref var, ref start, ref end, ref statements) => {
                 let mut current = start.clone();
                 while &current < end {
-                    statements_flattened.push(Statement::Definition(
+                    statements_flattened.push(FlatStatement::Definition(
                         self.use_variable(&var),
-                        Expression::Number(current.clone()),
+                        FlatExpression::Number(current.clone()),
                     ));
                     for s in statements {
                         self.flatten_statement(
@@ -634,11 +628,10 @@ impl Flattener {
                     current = T::one() + &current;
                 }
             }
-            ref s @ Statement::Compiler(..) => statements_flattened.push(s.clone()),
             Statement::MultipleDefinition(ref ids, ref rhs) => {
                 let rhs_subbed = rhs.apply_substitution(&self.substitution);
                 match rhs_subbed {
-                    FunctionCall(ref fun_id, ref exprs) => {
+                    Expression::FunctionCall(ref fun_id, ref exprs) => {
                         let rhs_flattened = self.flatten_function_call(
                             functions_flattened,
                             arguments_flattened,
@@ -654,7 +647,7 @@ impl Flattener {
                             if !(var == var_to_replace) && self.variables.contains(&var_to_replace) && !self.substitution.contains_key(&var_to_replace){
                                 self.substitution.insert(var_to_replace.clone().to_string(),var.clone());
                             }
-                            statements_flattened.push(Statement::Definition(var, rhs_flattened.expressions[i].clone()));
+                            statements_flattened.push(FlatStatement::Definition(var, rhs_flattened.expressions[i].clone()));
                         }
                     },
                     _ => panic!("Right hand side of a MultipleDefinition should be a FunctionCall")
@@ -671,14 +664,14 @@ impl Flattener {
     /// * `funct` - `Function` that will be flattened.
     pub fn flatten_function<T: Field>(
         &mut self,
-        functions_flattened: &mut Vec<Function<T>>,
+        functions_flattened: &mut Vec<FlatFunction<T>>,
         funct: Function<T>,
-    ) -> Function<T> {
+    ) -> FlatFunction<T> {
         self.variables = HashSet::new();
         self.substitution = HashMap::new();
         self.next_var_idx = 0;
         let mut arguments_flattened: Vec<Parameter> = Vec::new();
-        let mut statements_flattened: Vec<Statement<T>> = Vec::new();
+        let mut statements_flattened: Vec<FlatStatement<T>> = Vec::new();
         // push parameters
         for arg in funct.arguments {
             arguments_flattened.push(Parameter {
@@ -695,7 +688,7 @@ impl Flattener {
                 &stat,
             );
         }
-        Function {
+        FlatFunction {
             id: funct.id,
             arguments: arguments_flattened,
             statements: statements_flattened,
@@ -708,13 +701,13 @@ impl Flattener {
     /// # Arguments
     ///
     /// * `prog` - `Prog`ram that will be flattened.
-    pub fn flatten_program<T: Field>(&mut self, prog: Prog<T>) -> Prog<T> {
+    pub fn flatten_program<T: Field>(&mut self, prog: Prog<T>) -> FlatProg<T> {
         let mut functions_flattened = Vec::new();
         for func in prog.functions {
             let flattened_func = self.flatten_function(&mut functions_flattened, func);
             functions_flattened.push(flattened_func);
         }
-        Prog {
+        FlatProg {
             functions: functions_flattened,
         }
     }
@@ -771,14 +764,14 @@ mod multiple_definition {
 
         let mut flattener = Flattener::new(FieldPrime::get_required_bits());
         let mut functions_flattened = vec![
-            Function {
+            FlatFunction {
                 id: "foo".to_string(), 
                 arguments: vec![], 
-                statements: vec![Statement::Return(
-                    ExpressionList { 
+                statements: vec![FlatStatement::Return(
+                    FlatExpressionList { 
                         expressions: vec![
-                            Expression::Number(FieldPrime::from(1)), 
-                            Expression::Number(FieldPrime::from(2))
+                            FlatExpression::Number(FieldPrime::from(1)), 
+                            FlatExpression::Number(FieldPrime::from(2))
                         ]
                     }
                 )],
@@ -805,7 +798,7 @@ mod multiple_definition {
         assert_eq!(
             statements_flattened[0]
             ,
-            Statement::Definition("a".to_string(), Expression::Number(FieldPrime::from(1)))
+            FlatStatement::Definition("a".to_string(), FlatExpression::Number(FieldPrime::from(1)))
         );
     }
 
@@ -819,14 +812,14 @@ mod multiple_definition {
 
         let mut flattener = Flattener::new(FieldPrime::get_required_bits());
         let mut functions_flattened = vec![
-            Function {
+            FlatFunction {
                 id: "dup".to_string(), 
                 arguments: vec![Parameter { id: "x".to_string(), private: true }], 
-                statements: vec![Statement::Return(
-                    ExpressionList { 
+                statements: vec![FlatStatement::Return(
+                    FlatExpressionList { 
                         expressions: vec![
-                            Expression::Identifier("x".to_string()), 
-                            Expression::Identifier("x".to_string()), 
+                            FlatExpression::Identifier("x".to_string()), 
+                            FlatExpression::Identifier("x".to_string()), 
                         ]
                     }
                 )],
@@ -850,13 +843,10 @@ mod multiple_definition {
             &statement,
         );
 
-        println!("{:?}", statements_flattened);
-
-
         assert_eq!(
             statements_flattened[0]
             ,
-            Statement::Definition("dup_1_param_0".to_string(), Expression::Number(FieldPrime::from(2)))
+            FlatStatement::Definition("dup_1_param_0".to_string(), FlatExpression::Number(FieldPrime::from(2)))
         );
     }
 
@@ -870,13 +860,13 @@ mod multiple_definition {
 
         let mut flattener = Flattener::new(FieldPrime::get_required_bits());
         let mut functions_flattened = vec![
-            Function {
+            FlatFunction {
                 id: "foo".to_string(), 
                 arguments: vec![], 
-                statements: vec![Statement::Return(
-                    ExpressionList { 
+                statements: vec![FlatStatement::Return(
+                    FlatExpressionList { 
                         expressions: vec![
-                            Expression::Number(FieldPrime::from(1))
+                            FlatExpression::Number(FieldPrime::from(1))
                         ]
                     }
                 )],
@@ -900,7 +890,7 @@ mod multiple_definition {
         assert_eq!(
             statements_flattened[0]
             ,
-            Statement::Definition("a".to_string(), Expression::Number(FieldPrime::from(1)))
+            FlatStatement::Definition("a".to_string(), FlatExpression::Number(FieldPrime::from(1)))
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ extern crate bincode;
 extern crate regex;
 
 mod absy;
+mod flat_absy;
+mod parameter;
 mod parser;
 mod semantics;
 mod flatten;
@@ -33,7 +35,7 @@ use std::io::{BufWriter, Write, BufReader, BufRead, stdin};
 use std::collections::HashMap;
 use std::string::String;
 use field::{Field, FieldPrime};
-use absy::Prog;
+use flat_absy::FlatProg;
 use compile::compile;
 use r1cs::r1cs_program;
 use clap::{App, AppSettings, Arg, SubCommand};
@@ -203,7 +205,7 @@ fn main() {
 
             let path = PathBuf::from(sub_matches.value_of("input").unwrap());
             
-            let program_flattened: Prog<FieldPrime> = match compile(path) {
+            let program_flattened: FlatProg<FieldPrime> = match compile(path) {
                 Ok(p) => p,
                 Err(why) => panic!("Compilation failed: {}", why)
             };
@@ -256,7 +258,7 @@ fn main() {
                 Err(why) => panic!("couldn't open {}: {}", path.display(), why),
             };
 
-            let program_ast: Prog<FieldPrime> = match deserialize_from(&mut file, Infinite) {
+            let program_ast: FlatProg<FieldPrime> = match deserialize_from(&mut file, Infinite) {
                 Ok(x) => x,
                 Err(why) => {
                     println!("{:?}", why);
@@ -264,18 +266,11 @@ fn main() {
                 }
             };
 
-            // make sure the input program is actually flattened.
             let main_flattened = program_ast
                 .functions
                 .iter()
                 .find(|x| x.id == "main")
                 .unwrap();
-            for stat in main_flattened.statements.clone() {
-                assert!(
-                    stat.is_flattened(),
-                    format!("Input conditions not flattened: {}", &stat)
-                );
-            }
 
             // print deserialized flattened program
             println!("{}", main_flattened);
@@ -354,7 +349,7 @@ fn main() {
                 Err(why) => panic!("couldn't open {}: {}", path.display(), why),
             };
 
-            let program_ast: Prog<FieldPrime> = match deserialize_from(&mut file, Infinite) {
+            let program_ast: FlatProg<FieldPrime> = match deserialize_from(&mut file, Infinite) {
                 Ok(x) => x,
                 Err(why) => {
                     println!("{:?}", why);
@@ -362,18 +357,11 @@ fn main() {
                 }
             };
 
-            // make sure the input program is actually flattened.
             let main_flattened = program_ast
                 .functions
                 .iter()
                 .find(|x| x.id == "main")
                 .unwrap();
-            for stat in main_flattened.statements.clone() {
-                assert!(
-                    stat.is_flattened(),
-                    format!("Input conditions not flattened: {}", &stat)
-                );
-            }
 
             // print deserialized flattened program
             println!("{}", main_flattened);
@@ -563,7 +551,7 @@ mod tests {
 
             println!("Testing {:?}", path);
 
-            let program_flattened: Prog<FieldPrime> =
+            let program_flattened: FlatProg<FieldPrime> =
                 compile(path).unwrap();
 
             let (..) = r1cs_program(&program_flattened);
@@ -579,7 +567,7 @@ mod tests {
             };
             println!("Testing {:?}", path);
 
-            let program_flattened: Prog<FieldPrime> =
+            let program_flattened: FlatProg<FieldPrime> =
                 compile(path).unwrap();
 
             let (..) = r1cs_program(&program_flattened);

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -1,0 +1,20 @@
+use std::fmt;
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct Parameter {
+    pub id: String,
+    pub private: bool,
+}
+
+impl fmt::Display for Parameter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let visibility = if self.private { "private " } else { "" };
+        write!(f, "{}{}", visibility, self.id)
+    }
+}
+
+impl fmt::Debug for Parameter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Parameter(id: {:?})", self.id)
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,6 +71,7 @@ use std::io::prelude::*;
 use std::fs::File;
 use field::{Field, FieldPrime};
 use absy::*;
+use parameter::Parameter;
 
 #[derive(Clone, PartialEq)]
 struct Position {
@@ -1097,24 +1098,6 @@ fn parse_statement<T: Field>(
                 }),
             }
         }
-        (Token::Hash, s1, p1) => match parse_ide(&s1, &p1) {
-            (Token::Ide(x2), s2, p2) => match next_token(&s2, &p2) {
-                (Token::Eq, s3, p3) => match parse_expr(&s3, &p3) {
-                    Ok((e4, s4, p4)) => Ok((Statement::Compiler(x2, e4), s4, p4)),
-                    Err(err) => Err(err),
-                },
-                (t3, _, p3) => Err(Error {
-                    expected: vec![Token::Eq],
-                    got: t3,
-                    pos: p3,
-                }),
-            },
-            (t2, _, p2) => Err(Error {
-                expected: vec![Token::ErrIde],
-                got: t2,
-                pos: p2,
-            }),
-        },
         (Token::Return, s1, p1) => match parse_expression_list(s1, p1) {
             Ok((e2, s2, p2)) => match next_token(&s2, &p2) {
                 (Token::InlineComment(_), ref s3, _) => {
@@ -1144,7 +1127,6 @@ fn parse_statement<T: Field>(
                 Token::ErrNum,
                 Token::If,
                 Token::Open,
-                Token::Hash,
                 Token::Return,
             ],
             got: t1,

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -107,7 +107,7 @@ impl Checker {
 				self.check_expression_list(list)?;
 				Ok(())
 			}
-			Statement::Definition(id, expr) | Statement::Compiler(id, expr) => {
+			Statement::Definition(id, expr) => {
 				self.check_expression(expr)?;
 				self.scope.insert(Symbol {
 					id: id.to_string(),
@@ -239,6 +239,7 @@ impl Checker {
 mod tests {
 	use super::*;
 	use field::FieldPrime;
+	use parameter::Parameter;
 
 	pub fn new_with_args(scope: HashSet<Symbol>, level: usize, functions: HashSet<FunctionDeclaration>) -> Checker {
 		Checker {


### PR DESCRIPTION
We use the same (Rust) types for non-flattened code and flattened code. Therefore, we need to make checks at run time, for example `is_flattened`.

Instead, use different types to handle code and flattened code:
`flatten: Prog -> FlatProg`

Breaking:
- Removed `Compiler` statements from the parser as it outputs a Prog, not a FlatProg
- ~Changed flattening for linear combinations: they now must go through renaming which adds quite a lot of constraints. Linear combinations are already flattened so could bypass renaming, however now we need to convert from Expression to FlatExpression which isn't implemented yet for nested Expressions.~ fixed