### PR TITLE
Generalise compiler statements

### DIFF
--- a/src/executable.rs
+++ b/src/executable.rs
@@ -1,0 +1,70 @@
+//! Representation of a function that can run in any context (for example in libsnark)
+//!
+//! @file lambda.rs
+//! @author Thibaut Schaeffer <thibaut@schaeff.fr>
+//! @date 2018
+
+use field::Field;
+use absy::*;
+use std::collections::{BTreeMap};
+use parameter::Parameter;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct Zokrates<T: Field> {
+	pub function: Function<T>
+}
+
+impl<T: Field> Zokrates<T> {
+	pub fn new(id: String, expr: Expression<T>, args: Vec<Parameter>) -> Zokrates<T> {
+		Zokrates {
+			function: Function {
+				id: "_internal_".to_string(),
+				statements: vec![Statement::Return(ExpressionList {
+					expressions: vec![expr]
+				})],
+				return_count: 1,
+				arguments: args
+			}
+		}
+	}
+}
+
+impl<T: Field> Executable<T> for Zokrates<T> {
+	fn get_signature(&self) -> (usize, usize) {
+		(self.function.arguments.len(), self.function.return_count)
+	}
+	fn execute(&self, inputs: &Vec<T>) -> Result<Vec<T>, ()> {
+		assert!(self.function.statements.len() == 1);
+		let mut witness = BTreeMap::new();
+        witness.insert("~one".to_string(), T::one());
+        for (i, arg) in self.function.arguments.iter().enumerate() {
+            witness.insert(arg.id.to_string(), inputs[i].clone());
+        }
+		match self.function.statements[0] {
+			Statement::Return(ref list) => {
+				println!("{:?}", list);
+                for (i, val) in list.expressions.iter().enumerate() {
+                    let s = val.solve(&mut witness);
+                    witness.insert(format!("~out_{}", i).to_string(), s);
+                }
+
+                println!("{:?}", witness);
+
+
+                // witness is now full, only keep outputs
+                Ok(witness.into_iter().filter_map(|(k, v)| {
+                	match k.contains("~out_") {
+                		true => Some(v),
+                		_ => None
+                	}
+                }).collect())
+            },
+			_ => panic!("Zokrates directive should have exactly one Return statement and nothing else")
+		}
+	}
+}
+
+pub trait Executable<T: Field> {
+	fn get_signature(&self) -> (usize, usize);
+	fn execute(&self, inputs: &Vec<T>) -> Result<Vec<T>, ()>;
+}

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -15,6 +15,7 @@ use flat_absy::*;
 use parameter::Parameter;
 use direct_substitution::DirectSubstitution;
 use substitution::Substitution;
+use executable::Zokrates;
 
 /// Flattener, computes flattened program.
 pub struct Flattener {
@@ -177,13 +178,14 @@ impl Flattener {
                             box Expression::Number(T::one()),
                     ),
                 ));
-                statements_flattened.push(FlatStatement::Compiler(
-                    name_m.to_string(),
-                    Expression::IfElse(
+                statements_flattened.push(FlatStatement::ZokratesDirective(
+                    vec![name_x.to_string()],
+                    vec![name_m.to_string()],
+                    Box::new(Zokrates::new(name_x.to_string(), Expression::IfElse(
                             box Condition::Eq(Expression::Identifier(name_x.to_string()), Expression::Number(T::zero())),
                             box Expression::Number(T::one()),
                             box Expression::Div(box Expression::Number(T::one()), box Expression::Identifier(name_x.to_string())),
-                    ),
+                    ), vec![Parameter { id: name_x.to_string(), private: true }])),
                 ));
                 statements_flattened.push(FlatStatement::Condition(
                     FlatExpression::Identifier(name_y.to_string()),
@@ -291,6 +293,12 @@ impl Flattener {
                             let new_rhs = rhs.apply_substitution(&replacement_map);
                             statements_flattened
                                 .push(FlatStatement::Condition(new_lhs, new_rhs));
+                        }
+                        FlatStatement::ZokratesDirective(inputs, outputs, lambda) => {
+                            let renamed_inputs = inputs.iter().map(|i| format!("{}{}", prefix, i.clone())).collect();
+                            let renamed_outputs = outputs.iter().map(|o| format!("{}{}", prefix, o.clone())).collect();
+                            statements_flattened
+                                .push(FlatStatement::ZokratesDirective(renamed_inputs, renamed_outputs, lambda));
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod optimizer;
 mod r1cs;
 mod field;
 mod verification;
+mod executable;
 #[cfg(not(feature = "nolibsnark"))]
 mod libsnark;
 

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -335,7 +335,8 @@ pub fn r1cs_program<T: Field>(
                 b.push(b_row);
                 c.push(c_row);
             },
-            FlatStatement::Compiler(..) => continue
+            FlatStatement::Compiler(..) => continue,
+            FlatStatement::ZokratesDirective(..) => continue
         }
     }
     (variables, private_inputs_offset, a, b, c)


### PR DESCRIPTION
Add a generic compiler directive to call arbitrary Rust.
Right now implemented to refactor ZoKrates compiler statements, but will be applied to calls to, say, libsnark.

Postponed for now.