### PR TITLE
Remove path from zokrates_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,14 +222,13 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.0-git"
 dependencies = [
- "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -240,17 +239,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.1.43"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -272,13 +277,12 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.42"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -377,11 +381,6 @@ dependencies = [
 [[package]]
 name = "rustc-demangle"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -589,7 +588,10 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.2.0-git",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "reduce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,12 +635,12 @@ version = "0.1.0"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-"checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+"checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
+"checksum num-complex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68de83578789e0fbda3fa923035be83cf8bfd3b30ccfdecd5aa89bf8601f408e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
-"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+"checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
@@ -652,7 +654,6 @@ version = "0.1.0"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,13 +222,11 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.0-git"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -238,23 +236,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -271,16 +252,6 @@ name = "num-iter"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -588,10 +559,8 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.2.0-git",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "reduce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -635,12 +604,10 @@ version = "0.1.0"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-"checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
-"checksum num-complex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68de83578789e0fbda3fa923035be83cf8bfd3b30ccfdecd5aa89bf8601f408e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
-"checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -195,7 +195,7 @@ fn main() {
 
             let path = PathBuf::from(sub_matches.value_of("input").unwrap());
 
-            let location = path.parent().unwrap().to_path_buf();
+            let location = path.parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
 
             let should_optimize = sub_matches.occurrences_of("optimized") > 0;
 
@@ -205,7 +205,7 @@ fn main() {
 
             let mut reader = BufReader::new(file);
             
-            let program_flattened: FlatProg<FieldPrime> = match compile(&mut reader, location, Some(fs_resolve), should_optimize, should_include_gadgets) {
+            let program_flattened: FlatProg<FieldPrime> = match compile(&mut reader, Some(location), Some(fs_resolve), should_optimize, should_include_gadgets) {
                 Ok(p) => p,
                 Err(why) => panic!("Compilation failed: {}", why)
             };
@@ -550,10 +550,12 @@ mod tests {
 
             let file = File::open(path.clone()).unwrap();
 
+            let location = path.parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
+
             let mut reader = BufReader::new(file);
 
             let program_flattened: FlatProg<FieldPrime> =
-                compile(&mut reader, path, Some(fs_resolve), true, false).unwrap();
+                compile(&mut reader, Some(location), Some(fs_resolve), true, false).unwrap();
 
             let (..) = r1cs_program(&program_flattened);
         }
@@ -570,10 +572,12 @@ mod tests {
 
             let file = File::open(path.clone()).unwrap();
 
+            let location = path.parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
+
             let mut reader = BufReader::new(file);
 
             let program_flattened: FlatProg<FieldPrime> =
-                compile(&mut reader, path, Some(fs_resolve), true, false).unwrap();
+                compile(&mut reader, Some(location), Some(fs_resolve), true, false).unwrap();
 
             let (..) = r1cs_program(&program_flattened);
             let _ = program_flattened.get_witness(vec![FieldPrime::from(0)]).unwrap();

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -597,10 +597,12 @@ mod tests {
 
             let file = File::open(path.clone()).unwrap();
 
+            let location = path.parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
+
             let mut reader = BufReader::new(file);
 
             let program_flattened: FlatProg<FieldPrime> =
-                compile(&mut reader, path, Some(fs_resolve), true, false).unwrap();
+                compile(&mut reader, Some(location), Some(fs_resolve), true, false).unwrap();
 
             let (..) = r1cs_program(&program_flattened);
 

--- a/zokrates_core/Cargo.toml
+++ b/zokrates_core/Cargo.toml
@@ -12,7 +12,6 @@ libsnark = []
 
 [dependencies]
 libc = "0.2.0"
-num = "0.1.36"
 lazy_static = "0.1.*"
 reduce = "0.1.1"
 # cli
@@ -23,6 +22,11 @@ serde_derive = "1.0"
 serde_json = "1.0"
 bincode = "0.8.0"
 regex = "0.2"
+
+num = {path = "../../num"}
+num-bigint = {version = "0.1", default-features = false}
+num-traits = {version = "0.1", default-features = false}
+num-integer = {version = "0.1", default-features = false}
 
 [dev-dependencies]
 glob = "0.2.11"

--- a/zokrates_core/Cargo.toml
+++ b/zokrates_core/Cargo.toml
@@ -12,6 +12,8 @@ libsnark = []
 
 [dependencies]
 libc = "0.2.0"
+num = {version = "0.1.36", default-features = false}
+num-bigint = {version = "0.1.36", default-features = false}
 lazy_static = "0.1.*"
 reduce = "0.1.1"
 # cli
@@ -22,11 +24,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 bincode = "0.8.0"
 regex = "0.2"
-
-num = {path = "../../num"}
-num-bigint = {version = "0.1", default-features = false}
-num-traits = {version = "0.1", default-features = false}
-num-integer = {version = "0.1", default-features = false}
 
 [dev-dependencies]
 glob = "0.2.11"

--- a/zokrates_core/src/field.rs
+++ b/zokrates_core/src/field.rs
@@ -5,7 +5,7 @@
 // @date 2017
 
 use num::{Num, Integer, One, Zero};
-use num::bigint::{BigInt, BigUint, Sign, ToBigInt};
+use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 use std::convert::From;
 use std::ops::{Add, Div, Mul, Sub};
 use std::fmt;

--- a/zokrates_core/src/imports.rs
+++ b/zokrates_core/src/imports.rs
@@ -8,7 +8,6 @@ use std::fmt;
 use absy::*;
 use flat_absy::*;
 use field::Field;
-use std::path::PathBuf;
 use std::io;
 
 #[derive(PartialEq, Debug)]
@@ -40,44 +39,58 @@ impl From<io::Error> for Error {
 
 #[derive(PartialEq, Clone, Serialize, Deserialize)]
 pub struct Import {
-	source: PathBuf,
-	alias: String,
+	source: String,
+	alias: Option<String>,
 }
 
 impl Import {
 	pub fn new(source: String) -> Import {
 		Import {
-			source: PathBuf::from(source.clone()),
-			alias: PathBuf::from(source).file_stem().unwrap().to_os_string().to_string_lossy().to_string(),
+			source: source,
+			alias: None,
 		}
 	}
 
-	pub fn alias(&self) -> String {
-		self.alias.clone()
+	pub fn get_alias(&self) -> &Option<String> {
+		&self.alias
 	}
 
 	pub fn new_with_alias(source: String, alias: &String) -> Import {
 		Import {
-			source: PathBuf::from(source.clone()),
-			alias: alias.clone(),
+			source: source,
+			alias: Some(alias.clone()),
 		}
 	}
 
-	pub fn get_source(&self) -> &PathBuf {
+	pub fn get_source(&self) -> &String {
 		&self.source
 	}
 }
 
 impl fmt::Display for Import {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "import {} as {}", self.source.clone().into_os_string().into_string().unwrap(), self.alias)
+		match self.alias {
+			Some(ref alias) => {
+				write!(f, "import {} as {}", self.source, alias)
+			},
+			None => {
+				write!(f, "import {}", self.source)
+			}
+		}
 	}
 }
 
 impl fmt::Debug for Import {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "import(source: {}, alias: {})", self.source.clone().into_os_string().into_string().unwrap(), self.alias)
-    }
+    	match self.alias {
+			Some(ref alias) => {
+				write!(f, "import(source: {}, alias: {})", self.source, alias)
+			},
+			None => {
+				write!(f, "import(source: {})", self.source)
+			}
+	    }
+	}
 }
 
 pub struct Importer {
@@ -123,16 +136,16 @@ mod tests {
 	#[test]
 	fn create_with_no_alias() {
 		assert_eq!(Import::new("./foo/bar/baz.code".to_string()), Import {
-			source: PathBuf::from("./foo/bar/baz.code"),
-			alias: "baz".to_string(),
+			source: String::from("./foo/bar/baz.code"),
+			alias: None,
 		});
 	}
 
 	#[test]
 	fn create_with_alias() {
 		assert_eq!(Import::new_with_alias("./foo/bar/baz.code".to_string(), &"myalias".to_string()), Import {
-			source: PathBuf::from("./foo/bar/baz.code"),
-			alias: "myalias".to_string(),
+			source: String::from("./foo/bar/baz.code"),
+			alias: Some("myalias".to_string()),
 		});
 	}
 }

--- a/zokrates_core/src/lib.rs
+++ b/zokrates_core/src/lib.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate num;
+extern crate num_bigint;
 extern crate reduce; // better reduce function than Iter.fold
 extern crate serde; // serialization deserialization
 extern crate serde_json;

--- a/zokrates_core/src/libsnark.rs
+++ b/zokrates_core/src/libsnark.rs
@@ -215,7 +215,7 @@ fn vec_as_u8_32_array(vec: &Vec<u8>) -> [u8; 32] {
 mod tests {
     use super::*;
     use field::FieldPrime;
-    use num::bigint::BigUint;
+    use num_bigint::BigUint;
     use serde_json;
     use flat_absy::*;
     use standard;

--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -3,6 +3,18 @@ use std::path::PathBuf;
 use std::fs::File;
 use std::io;
 
-pub fn resolve(source: &PathBuf) -> Result<BufReader<File>, io::Error> {
-	File::open(source).and_then(|f| Ok(BufReader::new(f)))
+pub fn resolve(location: &Option<String>, source: &String) -> Result<(BufReader<File>, String, String), io::Error> {
+	let path = match location {
+		Some(location) => {
+			PathBuf::from(location).join(PathBuf::from(source))
+		},
+		None => {
+			PathBuf::from(source)
+		}
+	};
+
+	let next_location = path.parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
+	let alias = path.file_stem().unwrap().to_os_string().to_string_lossy().to_string();
+
+	File::open(path).and_then(|f| Ok((BufReader::new(f), next_location, alias)))
 }

--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -4,17 +4,82 @@ use std::fs::File;
 use std::io;
 
 pub fn resolve(location: &Option<String>, source: &String) -> Result<(BufReader<File>, String, String), io::Error> {
-	let path = match location {
-		Some(location) => {
-			PathBuf::from(location).join(PathBuf::from(source))
-		},
-		None => {
-			PathBuf::from(source)
-		}
-	};
+	// the fs resolver has to be provided a location, as it supports relative paths
+	match location {
+		Some(location) => resolve_with_location(location, source),
+		None => Err(io::Error::new(io::ErrorKind::Other, "No location provided"))
+	}
+}
 
-	let next_location = path.parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
-	let alias = path.file_stem().unwrap().to_os_string().to_string_lossy().to_string();
+fn resolve_with_location(location: &String, source: &String) -> Result<(BufReader<File>, String, String), io::Error> {
+	let path = 	PathBuf::from(location).join(PathBuf::from(source));
+	let (next_location, alias) = generate_next_parameters(&path)?;
 
 	File::open(path).and_then(|f| Ok((BufReader::new(f), next_location, alias)))
+}
+
+fn generate_next_parameters(path: &PathBuf) -> Result<(String, String), io::Error> {
+	match (path.parent(), path.file_stem()) {
+		(Some(parent), Some(stem)) => Ok(
+			(
+				parent.to_path_buf().into_os_string().into_string().unwrap(),
+				stem.to_os_string().to_string_lossy().to_string()
+			)
+		),
+		_ => Err(io::Error::new(io::ErrorKind::Other, "Invalid path"))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn valid_path_with_location() {
+		let (_, next_location, alias) = resolve(&Some(String::from("./src")), &String::from("lib.rs")).unwrap();
+		assert_eq!(next_location, String::from("./src"));
+		assert_eq!(alias, String::from("lib"));
+	}
+
+	#[test]
+	fn valid_path_without_location() {
+		let res = resolve(&None, &String::from("./src/lib.rs"));
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn non_existing_file() {
+		let res = resolve(&Some(String::from("./src")), &String::from("rubbish.rs"));
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn invalid_location() {
+		let res = resolve(&Some(String::from(",8!-$2abc")), &String::from("foo.code"));
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn invalid_file() {
+		let res = resolve(&Some(String::from("./src")), &String::from(",8!-$2abc"));
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn not_a_file() {
+		let res = resolve(&Some(String::from(".")), &String::from("/src/"));
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn no_parent() {
+		let res = resolve(&Some(String::from(".")), &String::from("."));
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn no_file_name() {
+		let res = resolve(&Some(String::from(".")), &String::from(""));
+		assert!(res.is_err());
+	}
 }


### PR DESCRIPTION
Even though we've extracted resolvers for the imports outside of the core, the API still uses PathBuf, which is specific to filesystem use cases.

Move one level up for the abstraction to use simple Strings, enabling resolvers to be developed and making compiling to wasm easier.

Also add the trick mentionned here https://github.com/udoprog/udoprog.github.io/blob/master/_posts/2018-02-19-porting-rust-to-wasm.md#big-numbers to enable targeting wasm.

Todo
- [x] error handling in resolver