### PR TITLE
Performance improvements

### DIFF
--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -210,42 +210,42 @@ fn main() {
                 Err(why) => panic!("Compilation failed: {}", why)
             };
 
-            // number of constraints the flattened program will translate to.
-            let num_constraints = &program_flattened.functions
-            .iter()
-            .find(|x| x.id == "main")
-            .unwrap().statements.len();
+            // // number of constraints the flattened program will translate to.
+            // let num_constraints = &program_flattened.functions
+            // .iter()
+            // .find(|x| x.id == "main")
+            // .unwrap().statements.len();
 
-            // serialize flattened program and write to binary file
-            let bin_output_path = Path::new(sub_matches.value_of("output").unwrap());
-            let mut bin_output_file = match File::create(&bin_output_path) {
-                Ok(file) => file,
-                Err(why) => panic!("couldn't create {}: {}", bin_output_path.display(), why),
-            };
+            // // serialize flattened program and write to binary file
+            // let bin_output_path = Path::new(sub_matches.value_of("output").unwrap());
+            // let mut bin_output_file = match File::create(&bin_output_path) {
+            //     Ok(file) => file,
+            //     Err(why) => panic!("couldn't create {}: {}", bin_output_path.display(), why),
+            // };
 
-            serialize_into(&mut bin_output_file, &program_flattened, Infinite).expect("Unable to write data to file.");
+            // serialize_into(&mut bin_output_file, &program_flattened, Infinite).expect("Unable to write data to file.");
 
-            // write human-readable output file
-            let hr_output_path = bin_output_path.to_path_buf().with_extension("code");
+            // // write human-readable output file
+            // let hr_output_path = bin_output_path.to_path_buf().with_extension("code");
 
-            let hr_output_file = match File::create(&hr_output_path) {
-                Ok(file) => file,
-                Err(why) => panic!("couldn't create {}: {}", hr_output_path.display(), why),
-            };
+            // let hr_output_file = match File::create(&hr_output_path) {
+            //     Ok(file) => file,
+            //     Err(why) => panic!("couldn't create {}: {}", hr_output_path.display(), why),
+            // };
 
-            let mut hrofb = BufWriter::new(hr_output_file);
-            write!(&mut hrofb, "{}\n", program_flattened).expect("Unable to write data to file.");
-            hrofb.flush().expect("Unable to flush buffer.");
+            // let mut hrofb = BufWriter::new(hr_output_file);
+            // write!(&mut hrofb, "{}\n", program_flattened).expect("Unable to write data to file.");
+            // hrofb.flush().expect("Unable to flush buffer.");
 
-            // debugging output
-            println!("Compiled program:\n{}", program_flattened);
+            // // debugging output
+            // println!("Compiled program:\n{}", program_flattened);
 
-            println!(
-                "Compiled code written to '{}', \nHuman readable code to '{}'. \nNumber of constraints: {}",
-                bin_output_path.display(),
-                hr_output_path.display(),
-                num_constraints
-            );
+            // println!(
+            //     "Compiled code written to '{}', \nHuman readable code to '{}'. \nNumber of constraints: {}",
+            //     bin_output_path.display(),
+            //     hr_output_path.display(),
+            //     num_constraints
+            // );
         }
         ("compute-witness", Some(sub_matches)) => {
             println!("Computing witness for:");

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -62,6 +62,10 @@ fn main() {
             .long("optimized")
             .help("perform optimization.")
             .required(false)
+        ).arg(Arg::with_name("light")
+            .long("light")
+            .help("Skip logs and human readable output")
+            .required(false)
         ).arg(Arg::with_name("gadgets")
             .long("gadgets")
             .help("include libsnark gadgets such as sha256")
@@ -201,6 +205,12 @@ fn main() {
 
             let should_include_gadgets = sub_matches.occurrences_of("gadgets") > 0;
 
+            let light = sub_matches.occurrences_of("light") > 0;
+
+            let bin_output_path = Path::new(sub_matches.value_of("output").unwrap());
+
+            let hr_output_path = bin_output_path.to_path_buf().with_extension("code");
+
             let file = File::open(path.clone()).unwrap();
 
             let mut reader = BufReader::new(file);
@@ -210,42 +220,44 @@ fn main() {
                 Err(why) => panic!("Compilation failed: {}", why)
             };
 
-            // // number of constraints the flattened program will translate to.
-            // let num_constraints = &program_flattened.functions
-            // .iter()
-            // .find(|x| x.id == "main")
-            // .unwrap().statements.len();
+            // number of constraints the flattened program will translate to.
+            let num_constraints = &program_flattened.functions
+            .iter()
+            .find(|x| x.id == "main")
+            .unwrap().statements.len();
 
-            // // serialize flattened program and write to binary file
-            // let bin_output_path = Path::new(sub_matches.value_of("output").unwrap());
-            // let mut bin_output_file = match File::create(&bin_output_path) {
-            //     Ok(file) => file,
-            //     Err(why) => panic!("couldn't create {}: {}", bin_output_path.display(), why),
-            // };
+            // serialize flattened program and write to binary file
+            let mut bin_output_file = match File::create(&bin_output_path) {
+                Ok(file) => file,
+                Err(why) => panic!("couldn't create {}: {}", bin_output_path.display(), why),
+            };
 
-            // serialize_into(&mut bin_output_file, &program_flattened, Infinite).expect("Unable to write data to file.");
+            serialize_into(&mut bin_output_file, &program_flattened, Infinite).expect("Unable to write data to file.");
 
-            // // write human-readable output file
-            // let hr_output_path = bin_output_path.to_path_buf().with_extension("code");
+            if !light {
+                // write human-readable output file
+                let hr_output_file = match File::create(&hr_output_path) {
+                    Ok(file) => file,
+                    Err(why) => panic!("couldn't create {}: {}", hr_output_path.display(), why),
+                };
 
-            // let hr_output_file = match File::create(&hr_output_path) {
-            //     Ok(file) => file,
-            //     Err(why) => panic!("couldn't create {}: {}", hr_output_path.display(), why),
-            // };
+                let mut hrofb = BufWriter::new(hr_output_file);
+                write!(&mut hrofb, "{}\n", program_flattened).expect("Unable to write data to file.");
+                hrofb.flush().expect("Unable to flush buffer.");
+            }
 
-            // let mut hrofb = BufWriter::new(hr_output_file);
-            // write!(&mut hrofb, "{}\n", program_flattened).expect("Unable to write data to file.");
-            // hrofb.flush().expect("Unable to flush buffer.");
+            if !light {
+                // debugging output
+                println!("Compiled program:\n{}", program_flattened);
+            }
 
-            // // debugging output
-            // println!("Compiled program:\n{}", program_flattened);
+            println!("Compiled code written to '{}'", bin_output_path.display());
 
-            // println!(
-            //     "Compiled code written to '{}', \nHuman readable code to '{}'. \nNumber of constraints: {}",
-            //     bin_output_path.display(),
-            //     hr_output_path.display(),
-            //     num_constraints
-            // );
+            if !light {
+                println!("Human readable code to '{}'", hr_output_path.display());
+            }
+
+            println!("Number of constraints: {}", num_constraints);
         }
         ("compute-witness", Some(sub_matches)) => {
             println!("Computing witness for:");

--- a/zokrates_core/src/flat_absy/flat_parameter.rs
+++ b/zokrates_core/src/flat_absy/flat_parameter.rs
@@ -21,7 +21,7 @@ impl fmt::Debug for FlatParameter {
 }
 
 impl FlatParameter {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> FlatParameter {
+    pub fn apply_substitution(self, substitution: &Substitution) -> FlatParameter {
         FlatParameter {
             id: substitution.get(&self.id).unwrap().to_string(),
             private: self.private

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -211,20 +211,20 @@ impl<T: Field> fmt::Debug for FlatStatement<T> {
 }
 
 impl<T: Field> FlatStatement<T> {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> FlatStatement<T> {
-        match *self {
-            FlatStatement::Definition(ref id, ref x) => FlatStatement::Definition(
-                match substitution.get(id) { 
+    pub fn apply_substitution(self, substitution: &Substitution) -> FlatStatement<T> {
+        match self {
+            FlatStatement::Definition(id, x) => FlatStatement::Definition(
+                match substitution.get(&id) { 
                     Some(z) => z.clone(), 
                     None => id.clone() 
                 }, 
                 x.apply_substitution(substitution)
             ),
-            FlatStatement::Return(ref x) => FlatStatement::Return(x.apply_substitution(substitution)),
-            FlatStatement::Condition(ref x, ref y) => {
+            FlatStatement::Return(x) => FlatStatement::Return(x.apply_substitution(substitution)),
+            FlatStatement::Condition(x, y) => {
                 FlatStatement::Condition(x.apply_substitution(substitution), y.apply_substitution(substitution))
             },
-            FlatStatement::Directive(ref d) => {
+            FlatStatement::Directive(d) => {
                 let new_outputs = d.outputs.iter().map(|o| match substitution.get(o) {
                     Some(z) => z.clone(),
                     None => o.clone()
@@ -234,7 +234,7 @@ impl<T: Field> FlatStatement<T> {
                     DirectiveStatement {
                         outputs: new_outputs,
                         inputs: new_inputs,
-                        helper: d.helper.clone()
+                        helper: d.helper
                     }
                 )
             }
@@ -253,10 +253,10 @@ pub enum FlatExpression<T: Field> {
 }
 
 impl<T: Field> FlatExpression<T> {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> FlatExpression<T> {
-        match *self {
-            ref e @ FlatExpression::Number(_) => e.clone(),
-            FlatExpression::Identifier(ref v) => {
+    pub fn apply_substitution(self, substitution: &Substitution) -> FlatExpression<T> {
+        match self {
+            e @ FlatExpression::Number(_) => e,
+            FlatExpression::Identifier(v) => {
                 let mut new_name = v.to_string();
                 loop {
                     match substitution.get(&new_name) {
@@ -265,19 +265,19 @@ impl<T: Field> FlatExpression<T> {
                     }
                 }
             }
-            FlatExpression::Add(ref e1, ref e2) => FlatExpression::Add(
+            FlatExpression::Add(e1, e2) => FlatExpression::Add(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FlatExpression::Sub(ref e1, ref e2) => FlatExpression::Sub(
+            FlatExpression::Sub(e1, e2) => FlatExpression::Sub(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FlatExpression::Mult(ref e1, ref e2) => FlatExpression::Mult(
+            FlatExpression::Mult(e1, e2) => FlatExpression::Mult(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FlatExpression::Div(ref e1, ref e2) => FlatExpression::Div(
+            FlatExpression::Div(e1, e2) => FlatExpression::Div(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             )
@@ -382,10 +382,9 @@ impl<T: Field> fmt::Display for FlatExpressionList<T> {
 }
 
 impl<T: Field> FlatExpressionList<T> {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> FlatExpressionList<T> {
-        let expressions: Vec<FlatExpression<T>> = self.expressions.iter().map(|e| e.apply_substitution(substitution)).collect();
+    pub fn apply_substitution(self, substitution: &Substitution) -> FlatExpressionList<T> {
         FlatExpressionList {
-            expressions: expressions
+            expressions: self.expressions.into_iter().map(|e| e.apply_substitution(substitution)).collect()
         }
     }
 }

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -391,7 +391,7 @@ impl Flattener {
 
                 // Handle complex parameters and assign values:
                 // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions
-                for (i, param_expr) in param_expressions.iter().enumerate() {
+                for (i, param_expr) in param_expressions.clone().into_iter().enumerate() {
                     let new_var;
                     let param_expr = param_expr.apply_substitution(&self.substitution);
 
@@ -710,12 +710,12 @@ impl Flattener {
         functions_flattened: &mut Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<FlatParameter>,
         statements_flattened: &mut Vec<FlatStatement<T>>,
-        stat: &TypedStatement<T>,
+        stat: TypedStatement<T>,
     ) {
-        match *stat {
-            TypedStatement::Return(ref exprs) => {
+        match stat {
+            TypedStatement::Return(exprs) => {
 
-                let flat_expressions = exprs.iter().map(|expr| {
+                let flat_expressions = exprs.into_iter().map(|expr| {
                     match expr {
                         TypedExpression::FieldElement(e) => {
                             let expr_subbed = e.apply_substitution(&self.substitution);
@@ -738,7 +738,7 @@ impl Flattener {
                     )
                 );
             }
-            TypedStatement::Definition(ref v, ref expr) => {
+            TypedStatement::Definition(v, expr) => {
 
                 // define n variables with n the number of primitive types for v_type
                 // assign them to the n primitive types for expr
@@ -764,7 +764,7 @@ impl Flattener {
                     _ => panic!("Definitions must have type FieldElement")
                 }
             }
-            TypedStatement::Condition(ref expr1, ref expr2) => {
+            TypedStatement::Condition(expr1, expr2) => {
 
                 // flatten expr1 and expr2 to n flattened expressions with n the number of primitive types for expr1
                 // add n conditions to check equality of the n expressions
@@ -813,14 +813,14 @@ impl Flattener {
                     _ => panic!("Conditions (Assertions) must be applied to expressions of type FieldElement")
                 }
             }
-            TypedStatement::For(ref var, ref start, ref end, ref statements) => {
-                let mut current = start.clone();
-                while &current < end {
+            TypedStatement::For(var, start, end, statements) => {
+                let mut current = start;
+                while current < end {
                     statements_flattened.push(FlatStatement::Definition(
                         self.use_variable(&var.id),
                         FlatExpression::Number(current.clone()),
                     ));
-                    for s in statements {
+                    for s in statements.clone() {
                         self.flatten_statement(
                             functions_flattened,
                             arguments_flattened,
@@ -831,7 +831,7 @@ impl Flattener {
                     current = T::one() + &current;
                 }
             }
-            TypedStatement::MultipleDefinition(ref vars, ref rhs) => {
+            TypedStatement::MultipleDefinition(vars, rhs) => {
 
                 // flatten the right side to p = sum(var_i.type.primitive_count) expressions
                 // define p new variables to the right side expressions 
@@ -839,14 +839,14 @@ impl Flattener {
                 let rhs_subbed = rhs.apply_substitution(&self.substitution);
                 
                 match rhs_subbed {
-                    TypedExpressionList::FunctionCall(ref fun_id, ref exprs, ref types) => {
+                    TypedExpressionList::FunctionCall(fun_id, exprs, types) => {
                         let rhs_flattened = self.flatten_function_call(
                             functions_flattened,
                             arguments_flattened,
                             statements_flattened,
-                            fun_id,
+                            &fun_id,
                             vars.len(),
-                            exprs,
+                            &exprs,
                         );
 
                         for (i, v) in vars.into_iter().enumerate() {
@@ -907,12 +907,12 @@ impl Flattener {
             }
         }
         // flatten statements in functions and apply substitution
-        for stat in &funct.statements {
+        for stat in funct.statements {
             self.flatten_statement(
                 functions_flattened,
                 &arguments_flattened,
                 &mut statements_flattened,
-                &stat,
+                stat,
             );
         }
 
@@ -1034,7 +1034,7 @@ mod multiple_definition {
             &mut functions_flattened,
             &arguments_flattened,
             &mut statements_flattened,
-            &statement,
+            statement,
         );
 
         assert_eq!(
@@ -1082,7 +1082,7 @@ mod multiple_definition {
             &mut functions_flattened,
             &arguments_flattened,
             &mut statements_flattened,
-            &statement,
+            statement,
         );
 
         assert_eq!(
@@ -1126,7 +1126,7 @@ mod multiple_definition {
             &mut functions_flattened,
             &arguments_flattened,
             &mut statements_flattened,
-            &statement,
+            statement,
         );
 
         assert_eq!(

--- a/zokrates_core/src/optimizer.rs
+++ b/zokrates_core/src/optimizer.rs
@@ -93,8 +93,8 @@ impl Optimizer {
 		}
 
 		// generate optimized statements by removing synonym declarations and renaming variables
-		let optimized_statements = funct.statements.iter().filter_map(|statement| {
-			match *statement {
+		let optimized_statements = funct.statements.into_iter().filter_map(|statement| {
+			match statement {
 				// filter out synonyms definitions
 				FlatStatement::Definition(_, FlatExpression::Identifier(_)) => {
 					None
@@ -107,15 +107,14 @@ impl Optimizer {
 		}).collect();
 
 		// generate optimized arguments by renaming them
-		let optimized_arguments = funct.arguments.iter().map(|arg| arg.apply_substitution(&self.substitution)).collect();
+		let optimized_arguments = funct.arguments.into_iter().map(|arg| arg.apply_substitution(&self.substitution)).collect();
 
-		// clone function
-		let mut optimized_funct = funct.clone();
-		// update statements with optimized ones
-		optimized_funct.statements = optimized_statements;
-		optimized_funct.arguments = optimized_arguments;
-
-		optimized_funct
+		FlatFunction {
+			id: funct.id,
+			arguments: optimized_arguments,
+			statements: optimized_statements,
+			return_count: funct.return_count
+		}
 	}
 }
 

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -76,6 +76,7 @@ impl Checker {
 				signature: func.signature
 			});
 		}
+
 		self.check_single_main()?;
 		Ok(TypedProg {
 			functions: checked_functions,
@@ -85,7 +86,7 @@ impl Checker {
 	}
 
 	fn check_single_main(&mut self) -> Result<(), Error> {
-		match self.functions.clone().into_iter().filter(|fun| fun.id == "main").count() {
+		match self.functions.iter().filter(|fun| fun.id == "main").count() {
 			1 => Ok(()),
 			0 => Err(Error { message: format!("No main function found") }),
 			n => Err(Error { message: format!("Only one main function allowed, found {}", n) })

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -295,10 +295,10 @@ pub enum BooleanExpression<T: Field> {
 }
 
 impl<T: Field> BooleanExpression<T> {
-    fn apply_substitution(&self, substitution: &Substitution) -> BooleanExpression<T> {
-        match *self {
-            BooleanExpression::Identifier(ref id) => {
-                let mut new_name = id.clone();
+    fn apply_substitution(self, substitution: &Substitution) -> BooleanExpression<T> {
+        match self {
+            BooleanExpression::Identifier(id) => {
+                let mut new_name = id;
                 loop {
                     match substitution.get(&new_name) {
                         Some(x) => new_name = x.to_string(),
@@ -306,23 +306,23 @@ impl<T: Field> BooleanExpression<T> {
                     }
                 }
             },
-            BooleanExpression::Lt(ref lhs, ref rhs) => BooleanExpression::Lt(
+            BooleanExpression::Lt(lhs, rhs) => BooleanExpression::Lt(
                 box lhs.apply_substitution(substitution),
                 box rhs.apply_substitution(substitution),
             ),
-            BooleanExpression::Le(ref lhs, ref rhs) => BooleanExpression::Le(
+            BooleanExpression::Le(lhs, rhs) => BooleanExpression::Le(
                 box lhs.apply_substitution(substitution),
                 box rhs.apply_substitution(substitution),
             ),
-            BooleanExpression::Eq(ref lhs, ref rhs) => BooleanExpression::Eq(
+            BooleanExpression::Eq(lhs, rhs) => BooleanExpression::Eq(
                 box lhs.apply_substitution(substitution),
                 box rhs.apply_substitution(substitution),
             ),
-            BooleanExpression::Ge(ref lhs, ref rhs) => BooleanExpression::Ge(
+            BooleanExpression::Ge(lhs, rhs) => BooleanExpression::Ge(
                 box lhs.apply_substitution(substitution),
                 box rhs.apply_substitution(substitution),
             ),
-            BooleanExpression::Gt(ref lhs, ref rhs) => BooleanExpression::Gt(
+            BooleanExpression::Gt(lhs, rhs) => BooleanExpression::Gt(
                 box lhs.apply_substitution(substitution),
                 box rhs.apply_substitution(substitution),
             ),
@@ -331,10 +331,10 @@ impl<T: Field> BooleanExpression<T> {
 }
 
 impl<T: Field> FieldElementExpression<T> {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> FieldElementExpression<T> {
-        match *self {
-            ref e @ FieldElementExpression::Number(_) => e.clone(),
-            FieldElementExpression::Identifier(ref id) => {
+    pub fn apply_substitution(self, substitution: &Substitution) -> FieldElementExpression<T> {
+        match self {
+            e @ FieldElementExpression::Number(_) => e,
+            FieldElementExpression::Identifier(id) => {
                 let mut new_name = id.clone();
                 loop {
                     match substitution.get(&new_name) {
@@ -343,36 +343,33 @@ impl<T: Field> FieldElementExpression<T> {
                     }
                 }
             }
-            FieldElementExpression::Add(ref e1, ref e2) => FieldElementExpression::Add(
+            FieldElementExpression::Add(e1, e2) => FieldElementExpression::Add(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FieldElementExpression::Sub(ref e1, ref e2) => FieldElementExpression::Sub(
+            FieldElementExpression::Sub(e1, e2) => FieldElementExpression::Sub(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FieldElementExpression::Mult(ref e1, ref e2) => FieldElementExpression::Mult(
+            FieldElementExpression::Mult(e1, e2) => FieldElementExpression::Mult(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FieldElementExpression::Div(ref e1, ref e2) => FieldElementExpression::Div(
+            FieldElementExpression::Div(e1, e2) => FieldElementExpression::Div(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FieldElementExpression::Pow(ref e1, ref e2) => FieldElementExpression::Pow(
+            FieldElementExpression::Pow(e1, e2) => FieldElementExpression::Pow(
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FieldElementExpression::IfElse(ref c, ref e1, ref e2) => FieldElementExpression::IfElse(
+            FieldElementExpression::IfElse(c, e1, e2) => FieldElementExpression::IfElse(
                 box c.apply_substitution(substitution),
                 box e1.apply_substitution(substitution),
                 box e2.apply_substitution(substitution),
             ),
-            FieldElementExpression::FunctionCall(ref i, ref p) => {
-                for param in p {
-                    param.apply_substitution(substitution);
-                }
-                FieldElementExpression::FunctionCall(i.clone(), p.clone())
+            FieldElementExpression::FunctionCall(i, p) => {
+                FieldElementExpression::FunctionCall(i, p.into_iter().map(|param| param.apply_substitution(substitution)).collect())
             },
         }
     }
@@ -474,7 +471,7 @@ impl<T: Field> fmt::Debug for FieldElementExpression<T> {
 
 
 impl<T: Field> TypedExpression<T> {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> TypedExpression<T> {
+    pub fn apply_substitution(self, substitution: &Substitution) -> TypedExpression<T> {
         match self {
             TypedExpression::Boolean(e) => e.apply_substitution(substitution).into(),
             TypedExpression::FieldElement(e) => e.apply_substitution(substitution).into(),
@@ -483,10 +480,10 @@ impl<T: Field> TypedExpression<T> {
 }
 
 impl<T: Field> TypedExpressionList<T> {
-    pub fn apply_substitution(&self, substitution: &Substitution) -> TypedExpressionList<T> {
-        match *self {
-            TypedExpressionList::FunctionCall(ref id, ref inputs, ref types) => {
-                TypedExpressionList::FunctionCall(id.clone(), inputs.iter().map(|i| i.apply_substitution(substitution)).collect(), types.clone())
+    pub fn apply_substitution(self, substitution: &Substitution) -> TypedExpressionList<T> {
+        match self {
+            TypedExpressionList::FunctionCall(id, inputs, types) => {
+                TypedExpressionList::FunctionCall(id, inputs.into_iter().map(|i| i.apply_substitution(substitution)).collect(), types)
             }
         }
     }


### PR DESCRIPTION
Add `--light` flag to disable human output to file.
Switch `apply_substitution` to take ownership to avoid clones

Measured a 10% speed up compiling `sha256.code`