### PR TITLE
Make get_variable_idx O(1), instead of O(n)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bincode"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +560,7 @@ name = "zokrates_core"
 version = "0.2.0"
 dependencies = [
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bimap 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -582,6 +588,7 @@ version = "0.1.0"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum bimap 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6b282b982237078bfac61a948a2198f185aceea8b9a6e794b70b96fd31923d3d"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"


### PR DESCRIPTION
This addresses #120.

Instead of storing all variables in a list, we now store them in a HashMap. This makes getting a variable run in O(1) instead of O(n), since we don't have to traverse the full list. At the end of `r1cs_expression` we convert the map back into a list, as the list format is required by the calling code.

To test, I ran `cargo test -- --ignored` and profiled the same program as in the original issue, now showing the bulk of time being spent in libsnark's c++ code.

<img width="1632" alt="screen shot 2018-09-07 at 15 17 21" src="https://user-images.githubusercontent.com/1200333/45224655-c09d5e00-b2ba-11e8-9ee2-5b4f9c967501.png">


Please comment suggestions on how to make this more elegant/efficient, this is my first Rust change.