### PR TITLE
changed readme as main is mandatory in default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ cd ZoKrates/target/release
 
 # Example
 
-To execute the program, perform the setup for the program, generate a proof
+First, create a file that describes the problem to proof:
 ```
-def add(a, b, c):
+def main(a, b, c):
   return a + b + c
 ```
-with `add(1, 2, 3)`, call
+then run the different phases of the protocol:
 ```
 ./zokrates compile -i 'add.code_path'
 ./zokrates compute-witness -a 1 2 3


### PR DESCRIPTION
Hello everybody,

seems like main is now mandatory in the current default branch.
This means that the example in the readme doesn't work anymore.

Thought it might be a good idea to fix this and created a PR.

Best,
Stefan