### PR TITLE
Adding Support for Proof Output

### DIFF
--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -34,7 +34,8 @@ fn main() {
     const VERIFICATION_CONTRACT_DEFAULT_PATH: &str = "verifier.sol";
     const WITNESS_DEFAULT_PATH: &str = "witness";
     const VARIABLES_INFORMATION_KEY_DEFAULT_PATH: &str = "variables.inf";
-
+    const JSON_PROOF_PATH: &str = "proof.json";
+    
     // cli specification using clap library
     let matches = App::new("ZoKrates")
     .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -181,6 +182,14 @@ fn main() {
             .takes_value(true)
             .required(false)
             .default_value(PROVING_KEY_DEFAULT_PATH)
+        ).arg(Arg::with_name("proofpath")
+            .short("j")
+            .long("proofpath")
+            .help("Path of the json proof file")
+            .value_name("FILE")
+            .takes_value(true)
+            .required(false)
+            .default_value(JSON_PROOF_PATH)
         ).arg(Arg::with_name("meta-information")
             .short("i")
             .long("meta-information")
@@ -551,10 +560,11 @@ fn main() {
             println!("Private inputs: {:?}", private_inputs);
 
             let pk_path = sub_matches.value_of("provingkey").unwrap();
+            let proof_path = sub_matches.value_of("proofpath").unwrap();
 
             // run libsnark
             #[cfg(feature="libsnark")]{
-                println!("generate-proof successful: {:?}", generate_proof(pk_path, public_inputs, private_inputs));
+                println!("generate-proof successful: {:?}", generate_proof(pk_path, proof_path, public_inputs, private_inputs));
             }
 
         }

--- a/zokrates_core/lib/wraplibsnark.cpp
+++ b/zokrates_core/lib/wraplibsnark.cpp
@@ -233,7 +233,8 @@ void exportInput(r1cs_primary_input<libff::Fr<libff::alt_bn128_pp>> input){
 }
 
 
-void printProof(r1cs_ppzksnark_proof<libff::alt_bn128_pp> proof){
+void printProof(r1cs_ppzksnark_proof<libff::alt_bn128_pp> proof, const char* proof_path, const uint8_t* public_inputs,
+            int public_inputs_length){
                 cout << "Proof:"<< endl;
                 cout << "A = Pairing.G1Point(" << outputPointG1AffineAsHex(proof.g_A.g)<< ");" << endl;
                 cout << "A_p = Pairing.G1Point(" << outputPointG1AffineAsHex(proof.g_A.h)<< ");" << endl;
@@ -243,6 +244,37 @@ void printProof(r1cs_ppzksnark_proof<libff::alt_bn128_pp> proof){
                 cout << "C_p = Pairing.G1Point(" << outputPointG1AffineAsHex(proof.g_C.h)<<");" << endl;
                 cout << "H = Pairing.G1Point(" << outputPointG1AffineAsHex(proof.g_H)<<");"<< endl;
                 cout << "K = Pairing.G1Point(" << outputPointG1AffineAsHex(proof.g_K)<<");"<< endl;
+
+                //create JSON file
+                std::stringstream ss;
+                ss << "{" << "\n";
+                  ss << "\t\"proof\":" << "\n";
+                    ss << "\t{" << "\n";
+                      ss << "\t\t\"A\":" <<outputPointG1AffineAsHexJson(proof.g_A.g) << ",\n";
+                      ss << "\t\t\"A_p\":" <<outputPointG1AffineAsHexJson(proof.g_A.h) << ",\n";
+                      ss << "\t\t\"B\":" << "\n";
+                        ss << "\t\t\t" << outputPointG2AffineAsHexJson(proof.g_B.g) << ",\n";
+                      ss << "\t\t\n";
+                      ss << "\t\t\"B_p\":" <<outputPointG1AffineAsHexJson(proof.g_B.h) << ",\n";
+                      ss << "\t\t\"C\":" <<outputPointG1AffineAsHexJson(proof.g_C.g) << ",\n";
+                      ss << "\t\t\"C_p\":" <<outputPointG1AffineAsHexJson(proof.g_C.h) << ",\n";
+                      ss << "\t\t\"H\":" <<outputPointG1AffineAsHexJson(proof.g_H) << ",\n";
+                      ss << "\t\t\"K\":" <<outputPointG1AffineAsHexJson(proof.g_K) << "\n";
+                    ss << "\t}," << "\n";
+                  //add input to json
+                  ss << "\t\"input\":" << "[";
+                  for (int i = 1; i < public_inputs_length; i++) {
+                    if(i!=1){
+                      ss << ",";
+                    }
+                    ss << libsnarkBigintFromBytes(public_inputs + i*32);
+                  }
+                  ss << "]";
+                ss << "}";
+
+                std::string s = ss.str();
+                //write json string to proof_path
+                writeToFile(proof_path, s);
 }
 
 bool _setup(const uint8_t* A, const uint8_t* B, const uint8_t* C, int A_len, int B_len, int C_len, int constraints, int variables, int inputs, const char* pk_path, const char* vk_path)
@@ -272,7 +304,7 @@ bool _setup(const uint8_t* A, const uint8_t* B, const uint8_t* C, int A_len, int
   return true;
 }
 
-bool _generate_proof(const char* pk_path, const uint8_t* public_inputs, int public_inputs_length, const uint8_t* private_inputs, int private_inputs_length)
+bool _generate_proof(const char* pk_path, const char* proof_path, const uint8_t* public_inputs, int public_inputs_length, const uint8_t* private_inputs, int private_inputs_length)
 {
   libff::inhibit_profiling_info = true;
   libff::inhibit_profiling_counters = true;
@@ -304,7 +336,7 @@ bool _generate_proof(const char* pk_path, const uint8_t* public_inputs, int publ
   auto proof = r1cs_ppzksnark_prover<libff::alt_bn128_pp>(pk, primary_input, auxiliary_input);
 
   // print proof
-  printProof(proof);
+  printProof(proof, proof_path, public_inputs, public_inputs_length);
   // TODO? print inputs
 
   return true;

--- a/zokrates_core/lib/wraplibsnark.cpp
+++ b/zokrates_core/lib/wraplibsnark.cpp
@@ -61,6 +61,17 @@ std::string outputPointG1AffineAsHex(libff::alt_bn128_G1 _p)
                 HexStringFromLibsnarkBigint(aff.Y.as_bigint());
 }
 
+std::string outputPointG1AffineAsHexJson(libff::alt_bn128_G1 _p)
+{
+        libff::alt_bn128_G1 aff = _p;
+        aff.to_affine_coordinates();
+        return
+                "[\"0x" +
+                HexStringFromLibsnarkBigint(aff.X.as_bigint()) +
+                "\", \"0x" +
+                HexStringFromLibsnarkBigint(aff.Y.as_bigint())+"\"]";
+}
+
 std::string outputPointG2AffineAsHex(libff::alt_bn128_G2 _p)
 {
         libff::alt_bn128_G2 aff = _p;
@@ -71,6 +82,18 @@ std::string outputPointG2AffineAsHex(libff::alt_bn128_G2 _p)
                 HexStringFromLibsnarkBigint(aff.X.c0.as_bigint()) + "], [0x" +
                 HexStringFromLibsnarkBigint(aff.Y.c1.as_bigint()) + ", 0x" +
                 HexStringFromLibsnarkBigint(aff.Y.c0.as_bigint()) + "]";
+}
+
+std::string outputPointG2AffineAsHexJson(libff::alt_bn128_G2 _p)
+{
+        libff::alt_bn128_G2 aff = _p;
+        aff.to_affine_coordinates();
+        return
+                "[[\"0x" +
+                HexStringFromLibsnarkBigint(aff.X.c1.as_bigint()) + "\", \"0x" +
+                HexStringFromLibsnarkBigint(aff.X.c0.as_bigint()) + "\"], [\"0x" +
+                HexStringFromLibsnarkBigint(aff.Y.c1.as_bigint()) + "\", \"0x" +
+                HexStringFromLibsnarkBigint(aff.Y.c0.as_bigint()) + "\"]]";
 }
 
 //takes input and puts it into constraint system

--- a/zokrates_core/lib/wraplibsnark.hpp
+++ b/zokrates_core/lib/wraplibsnark.hpp
@@ -26,7 +26,7 @@ bool _setup(const uint8_t* A,
           );
 
 bool _generate_proof(const char* pk_path,
-            const char* proof_path
+            const char* proof_path,
             const uint8_t* public_inputs,
             int public_inputs_length,
             const uint8_t* private_inputs,

--- a/zokrates_core/lib/wraplibsnark.hpp
+++ b/zokrates_core/lib/wraplibsnark.hpp
@@ -26,6 +26,7 @@ bool _setup(const uint8_t* A,
           );
 
 bool _generate_proof(const char* pk_path,
+            const char* proof_path
             const uint8_t* public_inputs,
             int public_inputs_length,
             const uint8_t* private_inputs,

--- a/zokrates_core/src/libsnark.rs
+++ b/zokrates_core/src/libsnark.rs
@@ -31,6 +31,7 @@ extern "C" {
     ) -> bool;
 
     fn _generate_proof(pk_path: *const c_char,
+                proof_path: *const c_char,
                 public_inputs: *const uint8_t,
                 public_inputs_length: c_int,
                 private_inputs: *const uint8_t,
@@ -156,11 +157,13 @@ pub fn setup<T: Field> (
 
 pub fn generate_proof<T: Field>(
     pk_path: &str,
+    proof_path: &str,
     public_inputs: Vec<T>,
     private_inputs: Vec<T>,
 ) -> bool {
 
     let pk_path_cstring = CString::new(pk_path).unwrap();
+    let proof_path_cstring = CString::new(proof_path).unwrap();
 
     let public_inputs_length = public_inputs.len();
     let private_inputs_length = private_inputs.len();
@@ -180,6 +183,7 @@ pub fn generate_proof<T: Field>(
     unsafe {
         _generate_proof(
             pk_path_cstring.as_ptr(),
+            proof_path_cstring.as_ptr(),
             public_inputs_arr[0].as_ptr(),
             public_inputs_length as i32,
             private_inputs_arr[0].as_ptr(),


### PR DESCRIPTION
Hi,
while trying to integrate ZoKrates into a blockchain toolchain, I noticed especially one missing feature: The proof cannot be exported to a file. Without this feature, automatic proof generation and publishing are not possible. Thus, I decided to implement an option which enables users to export the proof as JSON file when calling `generate-proof`
Besides the actual proof, the outputted JSON file also includes the public input parameters. 

The JSON is structured as follows:


{
* "proof":
{
"A":["0x ... ", "0x ..."],
"A_p": 
...
"K":["0x ... ", "0x ..."]
},
* "input":[1,2,3]

}


By default, the JSON is stored in `proof.json`. One can use the flag `--proofpath` or `-j` to specify the path.